### PR TITLE
Made gitignore include the auto-generated config folder

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # next.js build output
 .next
+
+config/


### PR DESCRIPTION
Otherwise, it would be easy to accidentally include the config folder when making a PR.