### PR TITLE
A better way to handle the spammers

### DIFF
--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -34,7 +34,7 @@ hack.chat has three permission levels. When you access a command, hack.chat auto
 |`ban`|`nick`|Disconnects the target nickname in the same channel as the calling socket and adds it to the rate limiter.|
 |`kick`|`nick`|Silently forces target client(s) into another channel. `nick` may be `string` or `array` of `string`s.|
 |`unban`|`ip` or `hash`|Removes the target ip from the rate limiter.|
-|`dumb`|`nick`|Mutes a user's (spammer's) texts such that it is only displayable to the user only.|
+|`dumb`|`nick`|Mutes a user's (spammer's) texts such that it is displayable to the user only.|
 |`speak`|`ip` or `hash`|Unmutes the user's (spammer's) texts and makes it displayable to everyone again.|
 
 # `admin`

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -34,6 +34,8 @@ hack.chat has three permission levels. When you access a command, hack.chat auto
 |`ban`|`nick`|Disconnects the target nickname in the same channel as the calling socket and adds it to the rate limiter.|
 |`kick`|`nick`|Silently forces target client(s) into another channel. `nick` may be `string` or `array` of `string`s.|
 |`unban`|`ip` or `hash`|Removes the target ip from the rate limiter.|
+|`dumb`|`nick`|Mutes a user's (spammer's) texts such that it is only displayable to the user only.|
+|`speak`|`ip` or `hash`|Unmutes the user's (spammer's) texts and makes it displayable to everyone again.|
 
 # `admin`
 

--- a/server/src/commands/core/chat.js
+++ b/server/src/commands/core/chat.js
@@ -51,10 +51,7 @@ exports.run = async (core, server, socket, data) => {
   if(core.muzzledHashes && core.muzzledHashes[socket.hash]){
       server.broadcast( payload, { channel: socket.channel, hash: socket.hash });
       if(core.muzzledHashes[socket.hash].allies){
-          let aqs = core.muzzledHashes[socket.hash].allies;
-          for(let i=0; i < aqs.length; i++){
-              server.broadcast( payload, { channel: socket.channel, nick: aqs[i] });
-          }
+          server.broadcast( payload, { channel: socket.channel, nick: core.muzzledHashes[socket.hash].allies });
       }
   } else {
       //else send it to everyone

--- a/server/src/commands/core/chat.js
+++ b/server/src/commands/core/chat.js
@@ -50,6 +50,12 @@ exports.run = async (core, server, socket, data) => {
 
   if(core.muzzledHashes[socket.hash]){
       server.broadcast( payload, { channel: socket.channel, hash: socket.hash });
+      if(core.muzzledHashes[socket.hash].allies){
+          let aqs = core.muzzledHashes[socket.hash].allies;
+          for(let i=0; i < aqs.length; i++){
+              server.broadcast( payload, { channel: socket.channel, nick: aqs[i] });
+          }
+      }
   } else {
       //else send it to everyone
       server.broadcast( payload, { channel: socket.channel});

--- a/server/src/commands/core/chat.js
+++ b/server/src/commands/core/chat.js
@@ -48,7 +48,12 @@ exports.run = async (core, server, socket, data) => {
     payload.trip = socket.trip;
   }
 
-  server.broadcast( payload, { channel: socket.channel });
+  if(core.muzzledHashes[socket.hash]){
+      server.broadcast( payload, { channel: socket.channel, hash: socket.hash });
+  } else {
+      //else send it to everyone
+      server.broadcast( payload, { channel: socket.channel});
+  }
 
   core.managers.stats.increment('messages-sent');
 };

--- a/server/src/commands/core/chat.js
+++ b/server/src/commands/core/chat.js
@@ -48,7 +48,7 @@ exports.run = async (core, server, socket, data) => {
     payload.trip = socket.trip;
   }
 
-  if(core.muzzledHashes[socket.hash]){
+  if(core.muzzledHashes && core.muzzledHashes[socket.hash]){
       server.broadcast( payload, { channel: socket.channel, hash: socket.hash });
       if(core.muzzledHashes[socket.hash].allies){
           let aqs = core.muzzledHashes[socket.hash].allies;

--- a/server/src/commands/core/join.js
+++ b/server/src/commands/core/join.js
@@ -115,6 +115,7 @@ exports.run = async (core, server, socket, data) => {
   socket.uType = uType;
   socket.nick = nick;
   socket.channel = channel;
+  socket.hash = server.getSocketHash(socket);
   if (trip !== null) socket.trip = trip;
   nicks.push(socket.nick);
 

--- a/server/src/commands/mod/dumb.js
+++ b/server/src/commands/mod/dumb.js
@@ -1,0 +1,58 @@
+/* 
+ * Description: Make a user (spammer) dumb
+ * Author: simple
+ */
+
+exports.init = (core) => {
+    core.muzzledHashes = {};
+}
+
+exports.run = async (core, server, socket, data) => {
+  if (socket.uType == 'user') {
+    // ignore if not mod or admin
+    return;
+  }
+
+  if (typeof data.nick !== 'string') {
+    return;
+  }
+  
+  let targetNick = data.nick;
+  let badClient = server.findSockets({ channel: socket.channel, nick: targetNick });
+
+  if (badClient.length === 0) {
+    server.reply({
+      cmd: 'warn',
+      text: 'Could not find user in channel'
+    }, socket);
+
+    return;
+  }
+
+  badClient = badClient[0];
+
+  if (badClient.uType !== 'user') {
+    server.reply({
+      cmd: 'warn',
+      text: 'This trick wont work on mods and admin'
+    }, socket);
+
+    return;
+  }
+  
+  core.muzzledHashes[badClient.hash] = true;
+  
+  server.broadcast({
+    cmd: 'info',
+    text: `${socket.nick} muzzled ${targetNick} in ${socket.channel}, userhash: ${badClient.hash}`
+  }, { uType: 'mod' });
+  
+}
+
+exports.requiredData = ['nick'];
+
+exports.info = {
+  name: 'dumb',
+  usage: 'dumb {nick}',
+  description: 'Cleanly disable a user messages and make him dumb'
+};

--- a/server/src/commands/mod/dumb.js
+++ b/server/src/commands/mod/dumb.js
@@ -40,7 +40,13 @@ exports.run = async (core, server, socket, data) => {
     return;
   }
   
-  core.muzzledHashes[badClient.hash] = true;
+  let record = core.muzzledHashes[badClient.hash] = {
+      dumb:true
+  }
+  
+  if(data.allies && data.allies.constructor === Array){
+      record.allies = data.allies;
+  }
   
   server.broadcast({
     cmd: 'info',
@@ -53,6 +59,6 @@ exports.requiredData = ['nick'];
 
 exports.info = {
   name: 'dumb',
-  usage: 'dumb {nick}',
+  usage: 'dumb {nick} [allies...]',
   description: 'Cleanly disable a user messages and make him dumb'
 };

--- a/server/src/commands/mod/dumb.js
+++ b/server/src/commands/mod/dumb.js
@@ -43,7 +43,7 @@ exports.run = async (core, server, socket, data) => {
       dumb:true
   }
   
-  if(data.allies && data.allies.constructor === Array){
+  if(data.allies && Array.isArray(data.allies)){
       record.allies = data.allies;
   }
   

--- a/server/src/commands/mod/dumb.js
+++ b/server/src/commands/mod/dumb.js
@@ -17,8 +17,7 @@ exports.run = async (core, server, socket, data) => {
     return;
   }
   
-  let targetNick = data.nick;
-  let badClient = server.findSockets({ channel: socket.channel, nick: targetNick });
+  let badClient = server.findSockets({ channel: socket.channel, nick: data.nick });
 
   if (badClient.length === 0) {
     server.reply({
@@ -50,7 +49,7 @@ exports.run = async (core, server, socket, data) => {
   
   server.broadcast({
     cmd: 'info',
-    text: `${socket.nick} muzzled ${targetNick} in ${socket.channel}, userhash: ${badClient.hash}`
+    text: `${socket.nick} muzzled ${data.nick} in ${socket.channel}, userhash: ${badClient.hash}`
   }, { uType: 'mod' });
   
 }

--- a/server/src/commands/mod/speak.js
+++ b/server/src/commands/mod/speak.js
@@ -1,0 +1,43 @@
+/* 
+ * Description: Pardon a dumb user to be able to speak again
+ * Author: simple
+ */
+
+
+exports.run = async (core, server, socket, data) => {
+  if (socket.uType == 'user') {
+    // ignore if not mod or admin
+    return;
+  }
+
+  if (typeof data.ip !== 'string' && typeof data.hash !== 'string') {
+    server.reply({
+      cmd: 'warn',
+      text: "hash:'targethash' or ip:'1.2.3.4' is required"
+    }, socket);
+
+    return;
+  }
+  
+  let target;
+
+  if (typeof data.ip === 'string') {
+    target = getSocketHash(data.ip);
+  } else {
+    target = data.hash;
+  }
+  
+  delete core.muzzledHashes[target];
+  
+  server.broadcast({
+    cmd: 'info',
+    text: `${socket.nick} unmuzzled : ${target}`
+  }, { uType: 'mod' });
+  
+}
+
+exports.info = {
+  name: 'speak',
+  usage: 'speak {[ip || hash]}',
+  description: 'Pardon a dumb user to be able to speak again'
+};


### PR DESCRIPTION
Its a new method to deal with the spammers and get rid of their unwanted texts without their knowing.
The mods may add a user to the muzzle records using the dumb command, handled by dumb.js.
And, chat.js wouldn't broadcast to all users in the channel but first check if the sender's ip hash is in the muzzle records, and if found it'll send the message to only to the clients of the same ip else the message will go to all as normal. By this way, a spammer won't even know when he was made out of the chat except if the mods don't leak.