### PR TITLE
Solved the sidebar scroll for mobile users

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -24,7 +24,7 @@ var frontpage = [
 	"",
 	"Legacy GitHub: https://github.com/AndrewBelt/hack.chat",
 	"Android apps: https://goo.gl/UkbKYy https://goo.gl/qasdSu https://goo.gl/fGQFQN",
-	"Other Softwares: https://github.com/hack-chat/3rd-party-software-list"
+	"Other Softwares: https://github.com/hack-chat/3rd-party-software-list",
 	"",
 	"Server and web client released under the WTFPL and MIT open source license.",
 	"No message history is retained on the hack.chat server."
@@ -414,12 +414,14 @@ updateInputSize();
 
 $('#sidebar').onmouseenter = $('#sidebar').ontouchstart = function (e) {
 	$('#sidebar-content').classList.remove('hidden');
+        $('#sidebar').classList.add('expand');
 	e.stopPropagation();
 }
 
 $('#sidebar').onmouseleave = document.ontouchstart = function () {
 	if (!$('#pin-sidebar').checked) {
 		$('#sidebar-content').classList.add('hidden');
+                $('#sidebar').classList.remove('expand');
 	}
 }
 

--- a/client/style.css
+++ b/client/style.css
@@ -52,6 +52,9 @@ ul li {
 .hidden {
   display: none;
 }
+.expand {
+    height: 90%;
+}
 .container {
   max-width: 600px;
   margin: 0 auto;

--- a/client/style.css
+++ b/client/style.css
@@ -53,7 +53,7 @@ ul li {
   display: none;
 }
 .expand {
-    height: 90%;
+    height: 100%;
 }
 .container {
   max-width: 600px;
@@ -111,6 +111,7 @@ ul li {
 }
 #sidebar-content {
   width: 180px;
+  padding-bottom: 10%;
 }
 @media only screen and (max-width: 600px) {
   .messages {


### PR DESCRIPTION
Solved the most annoying problem for the mobile clients, the sidebar scroll. Yeah, we've experienced this situation when we couldn't invite someone who's at the last end of the sidebar with our mobile browser cause sidebar spills out of the screen when there's a lot of users connected. But, now this is solved by fixing the height of sidebar container to 90% when shown and to 0% when hidden. Ah! I was really grieving to get rid of this shit.

Marzavec! Please add this and push to the hack.chat server and relief mobile user. ;)