### PR TITLE
Store the user nick locally but not the password

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -74,7 +74,7 @@ function join(channel) {
 		}
 
 		if (myNick) {
-			localStorageSet('my-nick', myNick);
+			localStorageSet('my-nick', myNick.split('#')[0]);
 			send({ cmd: 'join', channel: channel, nick: myNick });
 		}
 


### PR DESCRIPTION
This PR uses the `split()` method to get the non-sensitive part of user#password before storing it locally.

// Currently stored
user#password

// Proposal to store
user

This should fix #29. 