### PR TITLE
Admin pass stored as trip

### DIFF
--- a/server/src/commands/core/join.js
+++ b/server/src/commands/core/join.js
@@ -32,13 +32,12 @@ exports.parseNickname = (core, data) => {
   }
 
   let password = nickArray[1];
-  if (userInfo.nick.toLowerCase() == core.config.adminName.toLowerCase()) {
-    if (password !== core.config.adminPass) {
-      return 'You are not the admin, liar!';
-    } else {
-      userInfo.uType = 'admin';
-      userInfo.trip = 'Admin';
-    }
+  
+  if (hash(password + core.config.tripSalt) === core.config.adminTrip) {
+    userInfo.uType = 'admin';
+    userInfo.trip = 'Admin';
+  } else if (userInfo.nick.toLowerCase() == core.config.adminName.toLowerCase()) { // they've got the main-admin name while not being an admin
+    return 'You are not the admin, liar!';
   } else if (password) {
     userInfo.trip = hash(password + core.config.tripSalt);
   }

--- a/server/src/managers/config.js
+++ b/server/src/managers/config.js
@@ -16,6 +16,15 @@ const prompt = require('prompt');
 const path = require('path');
 const deSync = require('deasync');
 
+// For hashing the admin's password into a trip.
+const crypto = require('crypto');
+
+const hash = (password) => {
+  let sha = crypto.createHash('sha256');
+  sha.update(password);
+  return sha.digest('base64').substr(0, 6);
+};
+
 class ConfigManager {
   /**
     * Create a `ConfigManager` instance for (re)loading classes and config
@@ -65,6 +74,7 @@ class ConfigManager {
           default: currentConfig.adminPass,
           hidden: true,
           replace: '*',
+          before: value => hash(value)
         },
         websocketPort: {
           type: 'number',
@@ -98,7 +108,7 @@ class ConfigManager {
     let conf = {};
     conf = this.load();
 
-    // trip salt is the last core config question, wait until it's been populated
+    // websocketport is the last core config question, wait until it's been populated
     // TODO: update this to work with new plugin support
     while(conf === null || typeof conf.websocketPort === 'undefined') {
       deSync.sleep(100);

--- a/server/src/managers/config.js
+++ b/server/src/managers/config.js
@@ -44,6 +44,13 @@ class ConfigManager {
     // core server setup questions
     const questions = {
       properties: {
+        tripSalt: {
+          type: 'string',
+          required: !currentConfig.tripSalt,
+          default: currentConfig.tripSalt,
+          hidden: true,
+          replace: '*',
+        },
         adminName: {
           pattern: /^"?[a-zA-Z0-9_]+"?$/,
           type: 'string',
@@ -63,13 +70,6 @@ class ConfigManager {
           type: 'number',
           required: !currentConfig.websocketPort,
           default: currentConfig.websocketPort || 6060
-        },
-        tripSalt: {
-          type: 'string',
-          required: !currentConfig.tripSalt,
-          default: currentConfig.tripSalt,
-          hidden: true,
-          replace: '*',
         }
       }
     };
@@ -100,7 +100,7 @@ class ConfigManager {
 
     // trip salt is the last core config question, wait until it's been populated
     // TODO: update this to work with new plugin support
-    while(conf === null || typeof conf.tripSalt === 'undefined') {
+    while(conf === null || typeof conf.websocketPort === 'undefined') {
       deSync.sleep(100);
     }
 
@@ -127,10 +127,10 @@ class ConfigManager {
         ${chalk.white('Note:')} ${chalk.green('npm/yarn run config')} will re-run this utility.
 
         You will now be asked for the following:
+        -     ${chalk.magenta('      Salt')}, the salt for username trip
         -     ${chalk.magenta('Admin Name')}, the initial admin username
         -     ${chalk.magenta('Admin Pass')}, the initial admin password
         -     ${chalk.magenta('      Port')}, the port for the websocket
-        -     ${chalk.magenta('      Salt')}, the salt for username trip
         \u200b
       `);
 

--- a/server/src/managers/config.js
+++ b/server/src/managers/config.js
@@ -50,6 +50,8 @@ class ConfigManager {
     * @param {Object} optionalConfigs optional (non-core) module config
     */
   getQuestions (currentConfig, optionalConfigs) {
+    let salt = null; // this is so it can be accessed from adminTrip.
+
     // core server setup questions
     const questions = {
       properties: {
@@ -59,6 +61,10 @@ class ConfigManager {
           default: currentConfig.tripSalt,
           hidden: true,
           replace: '*',
+          before: value => {
+            salt = value;
+            return salt;
+          }
         },
         adminName: {
           pattern: /^"?[a-zA-Z0-9_]+"?$/,
@@ -68,13 +74,14 @@ class ConfigManager {
           default: currentConfig.adminName,
           before: value => value.replace(/"/g, '')
         },
-        adminPass: {
+        adminTrip: {
           type: 'string',
-          required: !currentConfig.adminPass,
-          default: currentConfig.adminPass,
+          required: !currentConfig.adminTrip,
+          default: currentConfig.adminTrip,
           hidden: true,
           replace: '*',
-          before: value => hash(value)
+          description: 'adminPass',
+          before: value => hash(value + salt)
         },
         websocketPort: {
           type: 'number',


### PR DESCRIPTION
Administrator password when created via config is stored by trip rather than by a plaintext password. 
the "adminPass" config property is renamed to "adminTrip"
The join command has been modified to check if their trip is the same as the stored admin trip, if it is then they are counted as an admin whether they have the main admin username or not. (Their trip is still set to 'Admin', so the trip for admin is technically secret)
There is still a main admin name under the same property name and users are still not allowed to login as that, but any names the Admin logs into aren't considered 'sacred' and can be used again once the Admin is no longer online on them. (Can't login as a user if that user is in the room.)
