### PR TITLE
Make Ctrl-Tab while typing in textarea exit early

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -396,6 +396,12 @@ $('#chatinput').onkeydown = function (e) {
 		updateInputSize();
 	} else if (e.keyCode == 9 /* TAB */) {
 		// Tab complete nicknames starting with @
+		
+		if (e.ctrlKey) {
+			// Skip autocompletion and tab insertion if user is pressing ctrl
+			// ctrl-tab is used by browsers to cycle through tabs
+			return;	
+		}
 		e.preventDefault();
 
 		var pos = e.target.selectionStart || 0;


### PR DESCRIPTION
Ctrl-Tab is used by browsers to cycle through tabs, and this would make so whilst pressing `ctrl`, it will not attempt to autocomplete or insert a tab.  
(Note: this is mainly because I've found it very slightly annoying to have to click off of the textarea to use ctrl-tab. I don't believe people normally press ctrl and tab at the same time for any other reason.)