### PR TITLE
Fix issue of the client not seeing disconnection if they have no myNick variable

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -177,7 +177,7 @@ function pushMessage(args) {
 	// Message container
 	var messageEl = document.createElement('div');
 
-	if (args.text.includes('@' + myNick.split('#')[0] + ' ')) {
+	if (typeof(myNick) === 'string' && args.text.includes('@' + myNick.split('#')[0] + ' ')) {
 		messageEl.classList.add('refmessage');
 	} else {
 		messageEl.classList.add('message');


### PR DESCRIPTION
Currently `pushMessage` does: `if (args.text.includes('@' + myNick.split('#')[0] + ' ')) {`
Now normally, this isn't an issue. If you press cancel on the prompt you'll normally never see a message (well you might see broadcasts, but I'm not sure), and even if you 'join' with an empty prompt that's still a string.  
The issue is, when you press cancel on the prompt (thus making myNick undefined/null) you will still be connected over the websocket. If the server were to die in that time (simulated by me via `ctrl-C` x) ) then you would normally get the message (generated by the client) of: `! Server disconnected. Attempting to reconnect. . .` even though you didn't join.  
But, since you didn't log in with a proper nick, you won't receive that message because `pushMessage` runs and it tries to run `myNick.split` which is incorrect due to `myNick` being null/undefined. This fixes that by checking if `myNick` is a string.  
  
Steps to do this, because I feel like I've explained badly:
- Launch a local server for the client.
- Launch the hack.chat server.  
- Open the client, making sure that you have no localStorage entries for `myNick`.  
- Get to the prompt which asks for your username. Click `Cancel`. Now `myNick` is `null`.  
- Kill the HC Server.  
- In the browser console you will see the error `Uncaught TypeError: Cannot read property 'split' of null`  
With this fix you will see the server disconnected message when the server dies. (Though, I'm unsure if people who don't login should see it anyway, but it should certainly not be causing an error)