### PR TITLE
Give greater insight into server errors for server owner

### DIFF
--- a/server/src/scripts/configLib/SetupWizard.js
+++ b/server/src/scripts/configLib/SetupWizard.js
@@ -87,6 +87,12 @@ class SetupWizard {
     if (typeof result.mods === 'undefined') {
       result.mods = [];
     }
+   
+    // If we should log errors with the err stack when they occur.
+    // See: CommandManager.js
+    if (typeof result.logErrDetailed === 'undefined') {
+      result.logErrDetailed = false;
+    }
 
     // finally create the actual JSON file
     try {

--- a/server/src/serverLib/CommandManager.js
+++ b/server/src/serverLib/CommandManager.js
@@ -268,13 +268,13 @@ class CommandManager {
     try {
       return await command.run(this.core, server, socket, data);
     } catch (err) {
-      let errText = `Failed to execute '${command.info.name}': ${err}`;
-      console.log(errText);
+      let errText = `Failed to execute '${command.info.name}': `;
+      console.log(errText + err.stack);
 
       this.handleCommand(server, socket, {
         cmd: 'socketreply',
         cmdKey: server.cmdKey,
-        text: errText
+        text: errText + err.toString()
       });
 
       return null;

--- a/server/src/serverLib/CommandManager.js
+++ b/server/src/serverLib/CommandManager.js
@@ -23,6 +23,9 @@ class CommandManager {
     this.core = core;
     this.commands = [];
     this.categories = [];
+    if (!this.core.config.hasOwnProperty('logErrDetailed')) {
+      this.core.config.logErrDetailed = false;
+    }
   }
 
   /**
@@ -269,7 +272,14 @@ class CommandManager {
       return await command.run(this.core, server, socket, data);
     } catch (err) {
       let errText = `Failed to execute '${command.info.name}': `;
-      console.log(errText + err.stack);
+      
+      // If we have more detail enabled, then we get the trace
+      // if it isn't, or the property doesn't exist, then we'll get only the message
+      if (this.core.config.logErrDetailed === true) {
+        console.log(errText + err.stack);
+      } else {
+        console.log(errText + err.toString())
+      }
 
       this.handleCommand(server, socket, {
         cmd: 'socketreply',


### PR DESCRIPTION
This makes so that when there's an error on the server due to running a command, then it will give greater detail.  
If a user ran a command in a way that caused a server error, then it would send the text, such as `Failed to execute 'thing': ReferenceError: core is not defined`, and also log that to the console. With this change, it will include the stack trace in the server log, but still only send the stripped down message to the client.