### PR TITLE
When saving Config, format it in a more human readable manner.

### DIFF
--- a/server/src/serverLib/ConfigManager.js
+++ b/server/src/serverLib/ConfigManager.js
@@ -62,7 +62,10 @@ class ConfigManager {
     const backupPath = await this.backup();
 
     try {
-      fse.writeJSONSync(this.configPath, this.config);
+      fse.writeJSONSync(this.configPath, this.config, {
+       // Indent with two spaces
+        spaces: 2,
+      });
       fse.removeSync(backupPath);
 
       return true;


### PR DESCRIPTION
Normally, when the config is saved to `config.json`, it is saved like so: `{"tripSalt":"xxxx","adminName":"MinusGix","adminTrip":"dKH9Jk","websocketPort":6060,"mods":[],"logErrDetailed": true}`  
All in a single line. Since this is meant to be edited if need be, this makes it annoying to read and edit. With the change I wrote (see: https://github.com/jprichardson/node-fs-extra/blob/HEAD/docs/writeJson-sync.md) it will add two spaces (as the code also uses two spaces) as indentation. Now it will be like:  
```
{
  "tripSalt": "xxxx",
  "adminName": "MinusGix",
  "adminTrip": "dKH9Jk",
  "websocketPort": 6060,
  "mods": [],
  "logErrDetailed": true,
}
```
Which is far easier to read an edit.