### PR TITLE
Extend logErrDetailed configuration option to errors when calling a hook

### DIFF
--- a/server/src/serverLib/MainServer.js
+++ b/server/src/serverLib/MainServer.js
@@ -438,9 +438,13 @@ class MainServer extends WsServer {
           try {
             payload = hooks[i].run(this.core, this, socket, payload);
           } catch (err) {
-            let errText = `Hook failure, '${type}', '${command}': ${err}`;
-            console.log(errText);
-            return errText;
+            let errText = `Hook failure, '${type}', '${command}': `;
+            if (this.core.config.logErrDetailed === true) {
+              console.log(errText + err.stack);
+            } else {
+              console.log(errText + err.toString());
+            }
+            return errText + err.toString();
           }
 
           // A hook function may choose to return false to prevent all further processing


### PR DESCRIPTION
This makes so that when you have an error in a module inside of a hook it will do the same behavior with error's as the CommandManager does, with the same code. Still sends limited message to user, but this provides the options of detailed stacktraces when an error occurs. 