### PR TITLE
Bugfix for @mentions

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -264,33 +264,16 @@ var COMMANDS = {
 		if (ignoredUsers.indexOf(args.nick) >= 0) {
 			return;
 		}
-
-		if (args.text.toLowerCase().includes("@" + myNick.toLowerCase().split("#")[0])) {
-			notify(args);
-			pushMessage(args);
-			// Indicate the message which was just added via style
-			document.getElementById("messages").lastChild.style.fontWeight = "bold"
-		} else {
-			pushMessage(args);
-		}
+		pushMessage(args);
 	},
 
 	info: function (args) {
 		args.nick = '*';
-
-		if (args.from != null && (args.type.toLowerCase() == "whisper" || args.type.toLowerCase() == "invite")) {
-			notify(args);
-			pushMessage(args);
-			// Make the message bold to stand out as a @mention
-			document.getElementById("messages").lastChild.style.fontWeight = "bold"
-		} else {
-			pushMessage(args);
-		}
+		pushMessage(args);
 	},
 
 	warn: function (args) {
 		args.nick = '!';
-		notify(args);
 		pushMessage(args);
 	},
 
@@ -331,8 +314,14 @@ function pushMessage(args) {
 	// Message container
 	var messageEl = document.createElement('div');
 
-	if (typeof (myNick) === 'string' && args.text.includes('@' + myNick.split('#')[0] + ' ')) {
+	if (
+		typeof (myNick) === 'string' && (
+			args.text.match(new RegExp('@' + myNick.split('#')[0], "gi")) ||
+			((args.type === "whisper" || args.type === "invite") && args.from)
+		)
+	) {
 		messageEl.classList.add('refmessage');
+		notify(args);
 	} else {
 		messageEl.classList.add('message');
 	}

--- a/client/style.css
+++ b/client/style.css
@@ -65,6 +65,9 @@ ul li {
 .message, .refmessage {
   padding-bottom: 1em;
 }
+.refmessage {
+  font-weight: bold;
+}
 .nick {
   float: left;
   width: 16em;


### PR DESCRIPTION
Cleaned up some code to reduce repetition, making using of existing `.refMessage` CSS class rather than setting an inline style on the fly for bold text.

Using regex to fix the problem with multiple users getting notifications (resolves issue #66).

No longer notifying on `warns`, because errors that occur when typing commands, like `/color red` shouldn't create any notifications. 

Speaking of @marzavec I can't find the code for colors anywhere, I wanted to add a local storage variable to save the color but it seems to not be in the repo.