### PR TITLE
Fix spacing issues from messages that refer to user

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -322,9 +322,9 @@ function pushMessage(args) {
 	) {
 		messageEl.classList.add('refmessage');
 		notify(args);
-	} else {
-		messageEl.classList.add('message');
 	}
+
+	messageEl.classList.add('message');
 
 	if (verifyNickname(myNick) && args.nick == myNick) {
 		messageEl.classList.add('me');


### PR DESCRIPTION
This fixes an issue where the spacing between messages shrinks if the message refers to you.  
Before change: `.message` is added to normal messages, but `.refmessage` is added to messages referring to the user. So `.message` is not on messages which refer to the user, which causes the spacing issues.  
After change: `.message` is applied to every message, even messages which refer to the issue. This provides more consistent styling. `.refmessage` is still applied to messages which refer to the user, so if anything uses those (aka nothing actually does), they still exist.  