### PR TITLE
Add ability to specify the channel that the invite command invites the user to

### DIFF
--- a/server/src/commands/core/invite.js
+++ b/server/src/commands/core/invite.js
@@ -26,7 +26,7 @@ export async function run(core, server, socket, data) {
   }
 
   let channel;
-  if (typeof data.to == 'string') {
+  if (typeof data.to === 'string') {
     channel = data.to;
   } else {
     channel = Math.random().toString(36).substr(2, 8);

--- a/server/src/commands/core/invite.js
+++ b/server/src/commands/core/invite.js
@@ -25,8 +25,12 @@ export async function run(core, server, socket, data) {
     return true;
   }
 
-  // generate common channel
-  const channel = Math.random().toString(36).substr(2, 8);
+  let channel;
+  if (typeof data.to == 'string') {
+    channel = data.to;
+  } else {
+    channel = Math.random().toString(36).substr(2, 8);
+  }
 
   // build and send invite
   const payload = {
@@ -67,7 +71,7 @@ export async function run(core, server, socket, data) {
 export const requiredData = ['nick'];
 export const info = {
   name: 'invite',
-  description: 'Generates a unique (more or less) room name and passes it to two clients',
+  description: 'Sends an invite to the target client with the provided channel, or a random channel.',
   usage: `
-    API: { cmd: 'invite', nick: '<target nickname>' }`,
+    API: { cmd: 'invite', nick: '<target nickname>', to: '<optional destination channel>' }`,
 };


### PR DESCRIPTION
This PR adds an optional (default still being random names) `to` parameter to the invite command. This lets the user have a specific channel to invite people too, and would also help for 'group' invites (A future addition to specify multiple users to invite to the same channel would also be nice, and could be a future PR).  
Doesn't modify the client, so client will still invite to random channels. Mainly usable by bots and people who know how to send 'raw' commands.