### PR TITLE
Add initial setup for nul

### DIFF
--- a/server/src/commands/core/join.js
+++ b/server/src/commands/core/join.js
@@ -20,6 +20,7 @@ export function parseNickname(core, data) {
     nick: '',
     uType: 'user',
     trip: null,
+    nul: server.nulId.user,
   };
 
   // seperate nick from password
@@ -34,6 +35,7 @@ export function parseNickname(core, data) {
   const password = nickArray[1];
 
   if (hash(password + core.config.tripSalt) === core.config.adminTrip) {
+    userInfo.nul = server.nulId.admin;
     userInfo.uType = 'admin';
     userInfo.trip = 'Admin';
   } else if (userInfo.nick.toLowerCase() === core.config.adminName.toLowerCase()) {
@@ -48,6 +50,7 @@ export function parseNickname(core, data) {
   core.config.mods.forEach((mod) => {
     if (userInfo.trip === mod.trip) {
       userInfo.uType = 'mod';
+      userInfo.nul = server.nulId.moderator;
     }
   });
 

--- a/server/src/serverLib/MainServer.js
+++ b/server/src/serverLib/MainServer.js
@@ -65,6 +65,19 @@ class MainServer extends WsServer {
       */
     this.lastErr = null;
 
+    /**
+     * User numerical level information constants.
+     * @type {Object}
+     */
+    this.nulId = {
+      admin: 10000, // site-wide
+      moderator: 9999, // site-wide
+      channelOwner: 1001,
+      channelModerator: 1000,
+      user: 100,
+    };
+
+
     this.setupServer();
     this.loadHooks();
   }


### PR DESCRIPTION
This makes so users that join get a property called `nul` (numeric user level), might as well keep that term that you proposed, though without making it a keyword :)
This will be broadcasted (at least on join) (so that bots can do things based on the number if need-be).  
I defined the 'inbuilt' ids in the `MainServer` class instance since that's passed to every the commands on run. It uses high numbers for the identifiers so that if need be there can be extra ones added (even by users) with plenty of space to spare. (Could be even more absurd, if you wish, but 900ish 'levels' for channel-owners and 9000ish for the server that are below current range is probably enough?).  
Though, I'm unsure if this is the best place to put it. There's three options that I can think of:  
- Move `nulId` on `CoreApp`.  (Ehh. It doesn't seem like the best place for it, in my opinion)
- Move `nulId` to `MainServer`. Is what is currently written in the PR.  
- Move `nulId` to it's own variable outside of `MainServer` which is then imported by files needing to use it. (This would shorten code, instead of writing `x => x.nul >= server.nulId.moderator` it becomes `x => x.nul >= nulId.moderator`. If done, the file it should be located in should be decided. (Would be a potential opportunity for a general utility file as well.)  
  
Then there's the options of how we use it...:
- Users use it in much the same way as they currently use uType, except slightly easier since it's numbers. `findSocket({ nul: x => x.nul >= server.nulId.moderator });` This is quite repetitive.  
- Providing a 'special' handling for `nul`. `findSocket({ nul: server.nulId.moderator });` would be exactly like the previous option. Against this due to making `findSocket` special-casey, when it's currently not.  
- Making it a class (which the 'instance' we use is still located *somewhere*), which has helper functions on it. `server.nulId.findSockets("moderator")`... but that's still bleh.  
  
There's probably some other options for the previous list, but I'm leaning towards the first, even if it is ugly and potentially error prone.  
  
Then there's the 'problem' of the name. `nulId` just spun off from the top of my head. It's confusing in that you might more naturally type `null`, and on some fonts (not mine, but the github's text editor which has probably caused some mistypes) the l and I will look the same.  
This is more of an 'asking for opinion(s)' rather than a 'real' pr, though if you think it works as it is that's a valid opinion on it x)  
  
Once this gets accepted (perhaps after being modified enough), I'll try 'phasing out' `uType` so that `nul` or whatever it's eventually called, is used instead. Probably dump a big PR with lots of small file changes x)