### PR TITLE
NUL Setup

### DIFF
--- a/server/src/commands/admin/addmod.js
+++ b/server/src/commands/admin/addmod.js
@@ -2,10 +2,12 @@
   Description: Adds the target trip to the mod list then elevates the uType
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin
-  if (socket.uType !== 'admin') {
+  if (!UAC.isAdmin(socket.level)) {
     return server.police.frisk(socket.address, 20);
   }
 
@@ -18,6 +20,7 @@ export async function run(core, server, socket, data) {
     for (let i = 0, l = newMod.length; i < l; i += 1) {
       // upgrade privilages
       newMod[i].uType = 'mod';
+      newMod[i].level = UAC.levels.moderator;
 
       // inform new mod
       server.send({
@@ -37,7 +40,7 @@ export async function run(core, server, socket, data) {
   server.broadcast({
     cmd: 'info',
     text: `Added mod: ${data.trip}`,
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   return true;
 }

--- a/server/src/commands/admin/listusers.js
+++ b/server/src/commands/admin/listusers.js
@@ -2,10 +2,12 @@
   Description: Outputs all current channels and their user nicks
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket) {
   // increase rate limit chance and ignore if not admin
-  if (socket.uType !== 'admin') {
+  if (!UAC.isAdmin(socket.level)) {
     return server.police.frisk(socket.address, 20);
   }
 

--- a/server/src/commands/admin/reload.js
+++ b/server/src/commands/admin/reload.js
@@ -2,10 +2,12 @@
   Description: Clears and resets the command modules, outputting any errors
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin
-  if (socket.uType !== 'admin') {
+  if (!UAC.isAdmin(socket.level)) {
     return server.police.frisk(socket.address, 20);
   }
 
@@ -28,17 +30,11 @@ export async function run(core, server, socket, data) {
     loadResult += `\nReason: ${data.reason}`;
   }
 
-  // reply with results
+  // send results to moderators (which the user using this command is higher than)
   server.reply({
     cmd: 'info',
     text: loadResult,
-  }, socket);
-
-  // notify mods of reload #transparency
-  server.broadcast({
-    cmd: 'info',
-    text: loadResult,
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   return true;
 }

--- a/server/src/commands/admin/removemod.js
+++ b/server/src/commands/admin/removemod.js
@@ -2,10 +2,12 @@
   Description: Removes target trip from the config as a mod and downgrades the socket type
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin
-  if (socket.uType !== 'admin') {
+  if (!UAC.isAdmin(socket.level)) {
     return server.police.frisk(socket.address, 20);
   }
 
@@ -18,6 +20,7 @@ export async function run(core, server, socket, data) {
     for (let i = 0, l = targetMod.length; i < l; i += 1) {
       // downgrade privilages
       targetMod[i].uType = 'user';
+      targetMod[i].level = UAC.levels.user;
 
       // inform ex-mod
       server.send({
@@ -39,7 +42,7 @@ export async function run(core, server, socket, data) {
   server.broadcast({
     cmd: 'info',
     text: `Removed mod: ${data.trip}`,
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   return true;
 }

--- a/server/src/commands/admin/saveconfig.js
+++ b/server/src/commands/admin/saveconfig.js
@@ -2,10 +2,12 @@
   Description: Writes the current config to disk
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket) {
   // increase rate limit chance and ignore if not admin
-  if (socket.uType !== 'admin') {
+  if (!UAC.isAdmin(socket.level)) {
     return server.police.frisk(socket.address, 20);
   }
 
@@ -17,17 +19,11 @@ export async function run(core, server, socket) {
     }, socket);
   }
 
-  // return success message
+  // return success message to moderators and admins
   server.reply({
     cmd: 'info',
     text: 'Config saved!',
-  }, socket);
-
-  // notify mods #transparency
-  server.broadcast({
-    cmd: 'info',
-    text: 'Config saved!',
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   return true;
 }

--- a/server/src/commands/admin/shout.js
+++ b/server/src/commands/admin/shout.js
@@ -2,10 +2,12 @@
   Description: Emmits a server-wide message as `info`
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin
-  if (socket.uType !== 'admin') {
+  if (!UAC.isAdmin(socket.level)) {
     return server.police.frisk(socket.address, 20);
   }
 

--- a/server/src/commands/core/chat.js
+++ b/server/src/commands/core/chat.js
@@ -2,6 +2,8 @@
   Description: Rebroadcasts any `text` to all clients in a `channel`
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module support functions
 const parseText = (text) => {
   // verifies user input is text
@@ -43,11 +45,12 @@ export async function run(core, server, socket, data) {
     cmd: 'chat',
     nick: socket.nick,
     text,
+    level: socket.level
   };
 
-  if (socket.uType === 'admin') {
+  if (UAC.isAdmin(socket.level)) {
     payload.admin = true;
-  } else if (socket.uType === 'mod') {
+  } else if (UAC.isModerator(socket.level)) {
     payload.mod = true;
   }
 

--- a/server/src/commands/core/join.js
+++ b/server/src/commands/core/join.js
@@ -2,6 +2,8 @@
   Description: Initial entry point, applies `channel` and `nick` to the calling socket
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module support functions
 const crypto = require('crypto');
 
@@ -20,6 +22,7 @@ export function parseNickname(core, data) {
     nick: '',
     uType: 'user',
     trip: null,
+    level: UAC.levels.user,
   };
 
   // seperate nick from password
@@ -36,6 +39,7 @@ export function parseNickname(core, data) {
   if (hash(password + core.config.tripSalt) === core.config.adminTrip) {
     userInfo.uType = 'admin';
     userInfo.trip = 'Admin';
+    userInfo.level = UAC.levels.admin;
   } else if (userInfo.nick.toLowerCase() === core.config.adminName.toLowerCase()) {
     // they've got the main-admin name while not being an admin
     return 'You are not the admin, liar!';
@@ -48,6 +52,7 @@ export function parseNickname(core, data) {
   core.config.mods.forEach((mod) => {
     if (userInfo.trip === mod.trip) {
       userInfo.uType = 'mod';
+      userInfo.level = UAC.levels.moderator;
     }
   });
 
@@ -113,6 +118,7 @@ export async function run(core, server, socket, data) {
     nick: userInfo.nick,
     trip: userInfo.trip || 'null',
     hash: userInfo.userHash,
+    level: userInfo.level,
   };
 
   // send join announcement and prep online set
@@ -126,6 +132,7 @@ export async function run(core, server, socket, data) {
   socket.nick = userInfo.nick;
   socket.channel = data.channel;
   socket.hash = userInfo.userHash;
+  socket.level = userInfo.level;
   if (userInfo.trip !== null) socket.trip = userInfo.trip;
 
   nicks.push(socket.nick);

--- a/server/src/commands/mod/dumb.js
+++ b/server/src/commands/mod/dumb.js
@@ -3,6 +3,8 @@
  * Author: simple
  */
 
+import * as UAC from "../utility/UAC/info";
+
 // module constructor
 export function init(core) {
   if (typeof core.muzzledHashes === 'undefined') {
@@ -13,7 +15,7 @@ export function init(core) {
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin or mod
-  if (socket.uType === 'user') {
+  if (!UAC.isModerator(socket.level)) {
     return server.police.frisk(socket.address, 10);
   }
 
@@ -35,7 +37,7 @@ export async function run(core, server, socket, data) {
   [badClient] = badClient;
 
   // likely dont need this, muting mods and admins is fine
-  if (badClient.uType !== 'user') {
+  if (badClient.level >= socket.level) {
     return server.reply({
       cmd: 'warn',
       text: 'This trick wont work on mods and admin',
@@ -56,7 +58,7 @@ export async function run(core, server, socket, data) {
   server.broadcast({
     cmd: 'info',
     text: `${socket.nick} muzzled ${data.nick} in ${socket.channel}, userhash: ${badClient.hash}`,
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   return true;
 }

--- a/server/src/commands/mod/moveuser.js
+++ b/server/src/commands/mod/moveuser.js
@@ -2,10 +2,12 @@
   Description: Removes the target socket from the current channel and forces a join event in another
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin or mod
-  if (socket.uType === 'user') {
+  if (!UAC.isModerator(socket.level)) {
     return server.police.frisk(socket.address, 10);
   }
 
@@ -30,7 +32,7 @@ export async function run(core, server, socket, data) {
 
   const badClient = badClients[0];
 
-  if (badClient.uType !== 'user') {
+  if (badClient.level >= socket.level) {
     return server.reply({
       cmd: 'warn',
       text: 'Cannot move other mods, how rude',

--- a/server/src/commands/mod/speak.js
+++ b/server/src/commands/mod/speak.js
@@ -3,6 +3,8 @@
  * Author: simple
  */
 
+import * as UAC from "../utility/UAC/info";
+
 // module constructor
 export function init(core) {
   if (typeof core.muzzledHashes === 'undefined') {
@@ -13,7 +15,7 @@ export function init(core) {
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin or mod
-  if (socket.uType === 'user') {
+  if (!UAC.isModerator(socket.level)) {
     return server.police.frisk(socket.address, 10);
   }
 
@@ -39,7 +41,7 @@ export async function run(core, server, socket, data) {
   server.broadcast({
     cmd: 'info',
     text: `${socket.nick} unmuzzled : ${target}`,
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   return true;
 }

--- a/server/src/commands/mod/unban.js
+++ b/server/src/commands/mod/unban.js
@@ -2,10 +2,12 @@
   Description: Removes a target ip from the ratelimiter
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket, data) {
   // increase rate limit chance and ignore if not admin or mod
-  if (socket.uType === 'user') {
+  if (!UAC.isModerator(socket.level)) {
     return server.police.frisk(socket.address, 10);
   }
 
@@ -47,7 +49,7 @@ export async function run(core, server, socket, data) {
   server.broadcast({
     cmd: 'info',
     text: `${socket.nick} unbanned: ${target}`,
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   // stats are fun
   core.stats.decrement('users-banned');

--- a/server/src/commands/mod/unbanall.js
+++ b/server/src/commands/mod/unbanall.js
@@ -2,10 +2,12 @@
   Description: Clears all bans and ratelimits
 */
 
+import * as UAC from "../utility/UAC/info";
+
 // module main
 export async function run(core, server, socket) {
   // increase rate limit chance and ignore if not admin or mod
-  if (socket.uType === 'user') {
+  if (!UAC.isModerator(socket.level)) {
     return server.police.frisk(socket.address, 10);
   }
 
@@ -24,7 +26,7 @@ export async function run(core, server, socket) {
   server.broadcast({
     cmd: 'info',
     text: `${socket.nick} unbanned all ip addresses`,
-  }, { uType: 'mod' });
+  }, { level: UAC.isModerator });
 
   return true;
 }

--- a/server/src/commands/utility/UAC/info.js
+++ b/server/src/commands/utility/UAC/info.js
@@ -1,0 +1,32 @@
+export const levels = {
+  admin            : 9999999,
+  moderator        : 999999,
+
+  channelOwner     : 99999,
+  channelModerator : 9999,
+
+  user             : 100,
+};
+
+export function isAdmin (level) {
+  return level >= levels.admin;
+}
+
+export function isModerator (level) {
+  return level >= levels.moderator;
+}
+
+export function isChannelOwner (level) {
+  return level >= levels.channelOwner;
+}
+
+export function isChannelModerator (level) {
+  return level >= levels.channelModerator;
+}
+
+export async function run (core, server, socket, data) {}
+
+export const info = {
+  name: 'uac_info',
+  description: 'This module contains information about UAC levels, and minor utility functions.',
+};


### PR DESCRIPTION
This commit adds a new `utility/nul` folder with an `info.js` within it.  
Info.js contains levels, and several utility functions which simplify the code and prevent accidental mistypings. (`isModerator` for example, which returns if the user is of Moderator level *or greater*.)  
The second commit of this makes join apply nul level to the socket (so it can be accessed), and also send it when the user joins. (So that bots may use it if they want, I guess.)  
The third commit modifies many of the commands that used `uType` filtering to use `nul` for their filtering/checks. `addmod`, `removemod` and `join` still use `uType` for backwards compatibility. (Though I believe it could be entirely removed, and we just say the broadcasted to client uType from the nul so then it's completely removed).  
Some commands have minor differences/issues with these changes. Many commands output that wasn't seen by admins can now be seen, as `isModerator` checks allow moderators and greater (admins) to see the messages. Some commands may have duplicated messages (due to sending to socket and all moderators, or something similar). Some commands that checked if you could do the action on the specified user (aka kick) and would basically just check if the target is not a user (and is thus a mod or admin) and tell them they can't do that. Now it checks if they're the same level (nul) or greater. This makes so admins can kick/ban mods (though, the commands aren't really meant to do that.. I think kick might make itself visible to a kicked mod and a mod can simply unban themselves if they got on a different ip address).
Also of minor note is that some commands that admins use would be more appropriate to broadcast to *every* admin, though there currently can't be more than one, but that could be a theoretical change to add in the feature.