### PR TITLE
Chat commands manager

### DIFF
--- a/server/src/commands/core/changenick.js
+++ b/server/src/commands/core/changenick.js
@@ -3,6 +3,8 @@
 */
 
 import * as UAC from '../utility/UAC/_info';
+import { Commands, ChatCommand } from '../utility/Commands/_main';
+import { RequirementMinimumParameterCount } from '../utility/Commands/_requirements';
 
 // module main
 export async function run(core, server, socket, data) {
@@ -86,39 +88,14 @@ export async function run(core, server, socket, data) {
 
 // module hook functions
 export function initHooks(server) {
-  server.registerHook('in', 'chat', this.nickCheck.bind(this), 29);
-}
-
-// hooks chat commands checking for /nick
-export function nickCheck(core, server, socket, payload) {
-  if (typeof payload.text !== 'string') {
-    return false;
-  }
-
-  if (payload.text.startsWith('/nick')) {
-    const input = payload.text.split(' ');
-
-    // If there is no nickname target parameter
-    if (input[1] === undefined) {
-      server.reply({
-        cmd: 'warn',
-        text: 'Refer to `/help nick` for instructions on how to use this command.',
-      }, socket);
-
-      return false;
-    }
-
-    const newNick = input[1].replace(/@/g, '');
-
-    this.run(core, server, socket, {
-      cmd: 'changenick',
-      nick: newNick,
-    });
-
-    return false;
-  }
-
-  return payload;
+  Commands.addCommand(new ChatCommand("nick")
+    .addRequirements(new RequirementMinimumParameterCount(1))
+    .onTrigger((_, core, server, socket, info) => {
+      run(core, server, socket, {
+        cmd: 'changenick',
+        nick: info.getSplitText()[1].replace(/@/g, ''),
+      });
+    }));
 }
 
 export const requiredData = ['nick'];

--- a/server/src/commands/core/chat.js
+++ b/server/src/commands/core/chat.js
@@ -3,6 +3,7 @@
 */
 
 import * as UAC from '../utility/UAC/_info';
+import { Commands, ChatCommand } from '../utility/Commands/_main';
 
 // module support functions
 const parseText = (text) => {
@@ -69,6 +70,14 @@ export async function run(core, server, socket, data) {
 
 // module hook functions
 export function initHooks(server) {
+  Commands.addCommand(new ChatCommand("myhash")
+    .onTrigger((_, core, server, socket, info) => {
+      server.reply({
+        cmd: 'info',
+        text: `Your hash: ${socket.hash}`
+      }, socket);
+    }));
+
   server.registerHook('in', 'chat', this.commandCheckIn.bind(this), 20);
   server.registerHook('in', 'chat', this.finalCmdCheck.bind(this), 254);
 }
@@ -79,12 +88,7 @@ export function commandCheckIn(core, server, socket, payload) {
     return false;
   }
 
-  if (payload.text.startsWith('/myhash')) {
-    server.reply({
-      cmd: 'info',
-      text: `Your hash: ${socket.hash}`,
-    }, socket);
-
+  if (Commands.trigger(core, server, socket, payload)) {
     return false;
   }
 

--- a/server/src/commands/core/emote.js
+++ b/server/src/commands/core/emote.js
@@ -2,6 +2,9 @@
   Description: Broadcasts an emote to the current channel
 */
 
+import { Commands, ChatCommand } from "../utility/Commands/_main";
+import { RequirementMinimumParameterCount } from "../utility/Commands/_requirements";
+
 // module support functions
 const parseText = (text) => {
   // verifies user input is text
@@ -56,40 +59,14 @@ export async function run(core, server, socket, payload) {
 
 // module hook functions
 export function initHooks(server) {
-  server.registerHook('in', 'chat', this.emoteCheck.bind(this), 30);
-}
-
-// hooks chat commands checking for /me
-export function emoteCheck(core, server, socket, payload) {
-  if (typeof payload.text !== 'string') {
-    return false;
-  }
-
-  if (payload.text.startsWith('/me ')) {
-    const input = payload.text.split(' ');
-
-    // If there is no emote target parameter
-    if (input[1] === undefined) {
-      server.reply({
-        cmd: 'warn',
-        text: 'Refer to `/help emote` for instructions on how to use this command.',
-      }, socket);
-
-      return false;
-    }
-
-    input.splice(0, 1);
-    const actionText = input.join(' ');
-
-    this.run(core, server, socket, {
-      cmd: 'emote',
-      text: actionText,
-    });
-
-    return false;
-  }
-
-  return payload;
+  Commands.addCommand(new ChatCommand("me")
+    .addRequirements(new RequirementMinimumParameterCount(1))
+    .onTrigger((_, core, server, socket, info) => {
+      run(core, server, socket, {
+        cmd: 'emote',
+        text: info.getTail(),
+      });
+    }));
 }
 
 export const requiredData = ['text'];

--- a/server/src/commands/core/help.js
+++ b/server/src/commands/core/help.js
@@ -2,6 +2,8 @@
   Description: Outputs the current command module list or command categories
 */
 
+import { Commands, ChatCommand } from "../utility/Commands/_main";
+
 // module main
 export async function run(core, server, socket, payload) {
   // check for spam
@@ -56,27 +58,13 @@ export async function run(core, server, socket, payload) {
 
 // module hook functions
 export function initHooks(server) {
-  server.registerHook('in', 'chat', this.helpCheck.bind(this), 28);
-}
-
-// hooks chat commands checking for /whisper
-export function helpCheck(core, server, socket, payload) {
-  if (typeof payload.text !== 'string') {
-    return false;
-  }
-
-  if (payload.text.startsWith('/help')) {
-    const input = payload.text.substr(1).split(' ', 2);
-
-    this.run(core, server, socket, {
-      cmd: input[0],
-      command: input[1],
-    });
-
-    return false;
-  }
-
-  return payload;
+  Commands.addCommand(new ChatCommand("help")
+    .onTrigger((_, core, server, socket, info) => {
+      run(core, server, socket, {
+        cmd: 'help',
+        command: info.getSplitText()[1],
+      });
+    }));
 }
 
 export const info = {

--- a/server/src/commands/core/morestats.js
+++ b/server/src/commands/core/morestats.js
@@ -2,6 +2,8 @@
   Description: Outputs more info than the legacy stats command
 */
 
+import { Commands, ChatCommand } from '../utility/Commands/_main';
+
 // module support functions
 const { stripIndents } = require('common-tags');
 
@@ -59,25 +61,14 @@ export async function run(core, server, socket) {
 
 // module hook functions
 export function initHooks(server) {
-  server.registerHook('in', 'chat', this.statsCheck.bind(this), 26);
+  Commands.addCommand(new ChatCommand("stats")
+    .onTrigger((_, core, server, socket, info) => {
+      run(core, server, socket, {
+        cmd: 'morestats'
+      });
+    }));
 }
 
-// hooks chat commands checking for /stats
-export function statsCheck(core, server, socket, payload) {
-  if (typeof payload.text !== 'string') {
-    return false;
-  }
-
-  if (payload.text.startsWith('/stats')) {
-    this.run(core, server, socket, {
-      cmd: 'morestats',
-    });
-
-    return false;
-  }
-
-  return payload;
-}
 
 export const info = {
   name: 'morestats',

--- a/server/src/commands/utility/Commands/_main.js
+++ b/server/src/commands/utility/Commands/_main.js
@@ -1,0 +1,273 @@
+/** Manages {ChatCommand}s */
+class ChatCommands {
+  constructor () {
+    /**
+      * The trigger which activates commands.
+      * @type {string}
+      */
+    this._trigger = '/';
+    /**
+      * An array of commands that are stored.
+      * @type {ChatCommand[]}
+      */
+    this.commands = [];
+  }
+
+  /**
+    * Returns the trigger. May be more than one character!
+    * @return {string}
+    */
+  getTrigger () {
+    return this._trigger;
+  }
+
+  /**
+    * Adds a command to the commands list.
+    * @param {ChatCommand} command
+    */
+  addCommand (command) {
+    this.commands.push(command);
+  }
+
+  /**
+    * Finds the command which should be ran.
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {Object} chatPayload
+    * @return {(ChatCommand|null)}
+    */
+  findApplicableCommand (core, server, socket, chatPayload) {
+    const commandInfo = new CommandInfo(this, chatPayload);
+
+    for (let i = 0; i < this.commands.length; i++) {
+      const command = this.commands[i];
+      if (command.shouldTrigger(this, core, server, socket, commandInfo)) {
+        return command;
+      }
+    }
+    return null;
+  }
+
+  /**
+    * Activates a command if one exists. If a command was ran then it returns true.
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {Object} chatPayload
+    * @return {boolean}
+    */
+  trigger (core, server, socket, chatPayload) {
+    // Don't even bother checking if there's no text.
+    if (typeof chatPayload.text !== 'string') {
+      return false;
+    }
+
+    const command = this.findApplicableCommand(core, server, socket, chatPayload);
+    if (command !== null) {
+      command.trigger(this, core, server, socket, new CommandInfo(this, chatPayload));
+      return true;
+    }
+
+    return false;
+  }
+};
+
+/** Information about the running command. */
+class CommandInfo {
+  /**
+    * Information about the command when it's being ran.
+    * Note: Many of these functions should only be called only as needed since there is no caching.
+    * @param {ChatCommands} chatCommands The ChatCommands instance which created this.
+    * @param {Object} chatPayload The original chat payload.
+    */
+  constructor (chatCommands, chatPayload) {
+    this._chatCommands = chatCommands;
+    this._chatPayload = chatPayload;
+  }
+
+  /**
+    * Returns the held chat payload. Should not be modified unless you know what you're doing.
+    * @return {Object}
+    */
+  getChatPayload () {
+    return this._chatPayload;
+  }
+
+  /**
+    * Returns the original text in the chat payload, if the text doesn't exist it returns an empty string.
+    * @return {string}
+    */
+  getText () {
+    return this._chatPayload.text || '';
+  }
+
+  /**
+    * Returns the text split by *spaces*
+    * @return {string[]}
+    */
+  getSplitText () {
+    return this.getText().split(' ');
+  }
+
+  /**
+    * Returns the name of the command (without the trigger). Lowercase.
+    * Most of the time it should not return null if ran in an actual command.
+    * @return {?string}
+    */
+  getCommandName () {
+    const text = this.getSplitText();
+    if (text.length === 0) {
+      return null;
+    }
+
+    if (!text[0].startsWith(this._chatCommands.getTrigger())) {
+      return null;
+    }
+
+    const triggerlessText = text[0]
+      .slice(this._chatCommands.getTrigger().length)
+      .trim()
+      .toLowerCase();
+    if (triggerlessText === '') {
+      return null;
+    }
+
+    return triggerlessText;
+  }
+
+  /**
+    * Returns the text after the /command part
+    * May be an empty array.
+    * @return {string[]}
+    */
+  getTail () {
+    return this.getSplitText().slice(1).join(' ');
+  }
+};
+
+/** Class for a command meant to be run in the chat */
+export class ChatCommand {
+  /**
+    * Trigger calback which is ran when the command is activated.
+    * @callback triggerCallback
+    * @param {ChatCommands} chatCommands ChatCommands instance which is activating this command.
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket The websocket of the client which ran this command.
+    * @param {CommandInfo} commandInfo Already parsed information about the text received.
+    */
+
+
+  /**
+    * Create a command. This is meant to be added to a ChatCommands instance.
+    * Extending this class is allowed, for customizing functions more than can be by default.
+    * @param {(string|string[])} names The names which the command should respond to.
+    */
+  constructor (names) {
+    if (typeof names === 'string') {
+      names = [names];
+    }
+
+    if (!Array.isArray(names)) {
+      console.error("Names was not a string or array in construction of Chat Command.");
+      process.exit(1);
+    }
+
+    /**
+      * The names this command responds to.
+      * @type {string[]}
+      */
+    this.names = names;
+
+    /**
+      * The callback to be ran when the command is triggered.
+      * @type {triggerCallback}
+      */
+    this._triggerCallback = null;
+
+    /**
+      * An array of requirements to apply before letting the command be ran.
+      * These are ran *after* the command has been 'validated' (same name, etc)
+      * @type {CommandRequirement[]}
+      */
+    this.requirements = [];
+  }
+
+  /**
+    * Returns the names that this command responds to.
+    * @return {string[]}
+    */
+  getNames () {
+    return this.names;
+  }
+
+  /**
+   * Adds new requirements to requirements list. Returns this command for chaining.
+   * @param  {...CommandRequirement} requirements 
+   */
+  addRequirements (...requirements) {
+    this.requirements.push(...requirements);
+    return this;
+  }
+
+  /**
+    * Sets the function to run when the command is triggered. Returns {ChatCommand} for chaining.
+    * @param {triggerCallback} callback
+    * @return {ChatCommand}
+    */
+  onTrigger (callback) {
+    this._triggerCallback = callback;
+    return this;
+  }
+
+  /**
+    * Decides if it should trigger the command.
+    * @param {ChatCommands} chatCommands The ChatCommands instance which is calling the function
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket Socket of client which is trying to run this command.
+    * @param {CommandInfo} commandInfo Already parsed information about the text received.
+    * @return {boolean}
+    */
+  shouldTrigger (chatCommands, core, server, socket, commandInfo) {
+    return this.getNames().includes(commandInfo.getCommandName());
+  }
+
+  /**
+    * Runs the trigger callback if it exists.
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {void}
+    */
+  trigger (chatCommands, core, server, socket, commandInfo) {
+    // We've verified that this is the command, and so we check any requirements placed upon it.
+    // This is checked here rather than shouldTrigger, because the requirements shouldn't let another command be ran.
+    for (let i = 0; i < this.requirements.length; i++) {
+      const requirement = this.requirements[i];
+
+      if (!requirement.isValid(chatCommands, core, server, socket, commandInfo)) {
+        let errorMessage = requirement.getErrorMessage(chatCommands, core, server, socket, commandInfo);
+        if (errorMessage === null) {
+          errorMessage = {
+            cmd: 'warn',
+            text: "There was an unknown error in using the command."
+          };
+        }
+
+        server.reply(errorMessage, socket);
+        return;
+      }
+    }
+
+    if (typeof this._triggerCallback === 'function') {
+      this._triggerCallback(chatCommands, core, server, socket, commandInfo);
+    }
+  }
+};
+
+
+export let Commands = new ChatCommands();

--- a/server/src/commands/utility/Commands/_requirements.js
+++ b/server/src/commands/utility/Commands/_requirements.js
@@ -1,0 +1,156 @@
+export class CommandRequirement {
+  /**
+    * Function which is ran when the error message is needed.
+    * @callback errorMessage
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {?String}
+    */
+
+  /**
+   * A requirement for a command to be ran.
+   * @param {errorMessage} errorMessageFunction
+   */
+  constructor (errorMessageFunction) {
+    this._errorMessageFunction = errorMessageFunction;
+  }
+
+  /**
+    * Checks if the command is valid. Returns true if it is.
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {boolean}
+    */
+  isValid (chatCommands, core, server, socket, commandInfo) {
+    return true;
+  }
+
+  /**
+    * Returns the message *payload* that should be sent to the offending client.
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {?Object}
+    */
+  getErrorMessage (chatCommands, core, server, socket, commandInfo) {
+    if (typeof this._errorMessageFunction === 'function') {
+      return {
+        cmd: 'warn',
+        text: this._errorMessageFunction(chatCommands, core, server, socket, commandInfo),
+      };
+    }
+    return null;
+  }
+};
+
+export class RequirementSimple extends CommandRequirement {
+  /**
+    * Function which is ran when the error message is needed.
+    * @callback validator
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {?String}
+    */
+
+  /**
+   * A simple requirement which is usually a one-off, and doesn't need to store any data.
+   * @param {validator} validatorFunction 
+   * @param {errorMessage} errorMessageFunction 
+   */
+  constructor (validatorFunction, errorMessageFunction) {
+    super(errorMessageFunction);
+
+    /**
+     * Function which checks if the requirement is met.
+     * @type {validator}
+     */
+    this._validatorFunction = validatorFunction;
+  }
+
+/**
+    * Checks if the command is valid. Returns true if it is.
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {boolean}
+    */
+  isValid (chatCommands, core, server, socket, commandInfo) {
+    if (typeof this._validatorFunction === 'function') {
+      return this._validatorFunction(chatCommands, core, server, commandInfo);
+    }
+    return true;
+  }
+};
+
+export class RequirementMinimumUACLevel extends CommandRequirement {
+  /**
+   * Creates a Requirement that requires a minimum UAC level.
+   * @param {number} requiredLevel
+   * @param {errorMessage} errorMessageFunction
+   */
+  constructor (requiredLevel, errorMessageFunction=(() => "You are not authorized to use this command.")) {
+    super(errorMessageFunction);
+
+    /**
+     * The minimum UAC level to use the command.
+     * @type {number}
+     */
+    this._requiredLevel = requiredLevel;
+  }
+
+  /**
+    * Checks if the command is valid. Returns true if it is.
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {boolean}
+    */
+  isValid (chatCommands, core, server, socket, commandInfo) {
+    return socket.level >= this._requiredLevel;
+  }
+};
+
+export class RequirementMinimumParameterCount extends CommandRequirement {
+  /**
+   * Creates a Requirement that requires a minimum of (simple) parameters from the command.
+   * @param {number} requiredAmount
+   * @param {errorMessage} errorMessageFunction
+   */
+  constructor (requiredAmount, errorMessageFunction=(() => "Not enough parameters supplied to command.")) {
+    super(errorMessageFunction);
+
+    /**
+     * The minimum required amount of parameters.
+     * @type {number}
+     */
+    this._requiredAmount = requiredAmount;
+  }
+
+  /**
+    * Checks if the command is valid. Returns true if it is.
+    * @param {ChatCommands} chatCommands
+    * @param {CoreApp} core
+    * @param {MainServer} server
+    * @param {WebSocket} socket
+    * @param {CommandInfo} commandInfo
+    * @return {boolean}
+    */
+  isValid (chatCommands, core, server, socket, commandInfo) {
+    return (commandInfo.getSplitText().length - 1) >= this._requiredAmount;
+  }
+};


### PR DESCRIPTION
This PR adds code to make adding new chat commands easier, reduce duplicated code, and make it less potentially buggy.  
A new folder is added in utility named `Commands`.  
The main class is `ChatCommands` which holds all of the commands and the trigger which activates commands ('/', but it can be changed and should support more than one character).  
Commands are added like so:  
```javascript
Commands.addCommand(new ChatCommand("myhash")
    .onTrigger((_, core, server, socket, info) => {
      server.reply({
        cmd: 'info',
        text: `Your hash: ${socket.hash}`
      }, socket);
    }));
```
The command can have multiple names (simply pass in an array when creating it), though they should all be lowercase. The `Commands` is a readily created instance of `ChatCommands` meant for holding all of the commands, it is located in `utility/Commands/_main.js`.  
`onTrigger` is ran whenever the command is, well, triggered. It received `(ChatCommands, CoreApp, MainServer, WebSocket, CommandInfo)`  
`CommandInfo` is another class and is essentially a bunch of utility functions for commands that also holds the original chat message (and the chat message can be retrieved from it).  
`ChatCommand` is the main command class. It has a `string[]` of names it responds to, the onTrigger callback, and a list of 'requirements'.  
Requirements are created in `utility/Commands/_requirements.js` and are Requirements that must be satisfied once the command has been chosen. (Aka, it's seen that `/command` matches the command it should activate, and so it checks the requirements.). Requirements are meant for cases which should show an error message if they fail for that specific command. Such as requiring a specific (minimum) number of parameters (`/whisper`, `/nick`, etc), a minimum UAC level (`/ban`, `/kick`, though those aren't added in this pr.).  
Requirements are used like:  
```javascript
  Commands.addCommand(new ChatCommand("me")
    .addRequirements(new RequirementMinimumParameterCount(1))
    .onTrigger((_, core, server, socket, info) => {
      run(core, server, socket, {
        cmd: 'emote',
        text: info.getTail(),
      });
    }));
}
```
`ChatCommand#addRequirements` simply takes a variable number of requirements and adds them to an array it holds.
(There is also a `RequirementSimple` which simply takes an arrow-function for checking if it's valid, which is useful in scenarios which are one-off in their requirements (See: whisper reply command) and don't need to store data.)  
This example also showcases a function on the last parameter, `CommandInfo`, which simply returns all of the text not including the `/command ` part.  
  
This was originally written inside `chat.js`, but I realized it should be put into it's own file since there was many lines of code and it would make so you don't have to depend on chat.js existing.  
  
Currently adding of commands is done in `initHooks`, despite it not actually using hooks. I didn't really look too much for alternatives, so open to suggestions on that.
There's probably styling issues, issues in how this is done, and more, but it seems to at least work. So this is more of a request for comments / review for anything that needs to be fixed/changed/etc.