### PR TITLE
Add more info to ban commands

### DIFF
--- a/server/src/commands/mod/ban.js
+++ b/server/src/commands/mod/ban.js
@@ -46,12 +46,16 @@ export async function run(core, server, socket, data) {
   server.broadcast({
     cmd: 'info',
     text: `Banned ${targetNick}`,
+    user: UAC.getUserDetails(badClient),
   }, { channel: socket.channel, level: (level) => level < UAC.levels.moderator });
 
   // notify mods
   server.broadcast({
     cmd: 'info',
     text: `${socket.nick}#${socket.trip} banned ${targetNick} in ${socket.channel}, userhash: ${badClient.hash}`,
+    channel: socket.channel,
+    user: UAC.getUserDetails(badClient),
+    banner: UAC.getUserDetails(socket),
   }, { level: UAC.isModerator });
 
   // force connection closed

--- a/server/src/commands/utility/UAC/_info.js
+++ b/server/src/commands/utility/UAC/_info.js
@@ -91,6 +91,23 @@ export function isTrustedUser(level) {
 }
 
 /**
+  * Return an object containing public information about the socket
+  * @public
+  * @param {WebSocket} socket Target client
+  * @return {Object}
+  */
+export function getUserDetails(socket) {
+  return {
+    uType: socket.uType,
+    nick: socket.nick,
+    trip: socket.trip || 'null',
+    hash: socket.hash,
+    level: socket.level,
+    userid: socket.userid,
+  };
+}
+
+/**
   * Returns true if the nickname is valid
   * @public
   * @param {string} nick Nickname to verify


### PR DESCRIPTION
Meant to make this yesterday, but internet was being annoying.  
This adds some more information to the ban announcements.  
Normal clients receive: `badClient`'s nick, has, and trip as properties.  
\>=Moderators receive those and the nick/trip of the user who banned them. As well as the channel it was done in.  
This will allow clients/bots to receive that data without parsing (and some of which wasn't available before).  
(Query: Should this include the hash of the user who banned them in the response to \>=Moderators? If so, I can modify the PR.)