### PR TITLE
Switch accessed property to hash

### DIFF
--- a/server/src/commands/core/join.js
+++ b/server/src/commands/core/join.js
@@ -144,7 +144,7 @@ export async function run(core, server, socket, data) {
       nick: newPeerList[i].nick,
       trip: newPeerList[i].trip,
       utype: newPeerList[i].uType, /* @legacy */
-      hash: newPeerList[i].userHash,
+      hash: newPeerList[i].hash,
       level: newPeerList[i].level,
       userid: newPeerList[i].userid,
       channel: data.channel,
@@ -166,7 +166,7 @@ export async function run(core, server, socket, data) {
     nick: socket.nick,
     trip: socket.trip,
     utype: socket.uType,
-    hash: socket.userHash,
+    hash: socket.hash,
     level: socket.level,
     userid: socket.userid,
     channel: data.channel,


### PR DESCRIPTION
The new modification to the join commands accesses the hash with `.userHash` (the old term in the join file), which would lead to the value being `undefined`. This PR fixes that by accessing the correct `hash` property instead.  
(Only noticed this while trying to write a different PR. It's not on the live server seemingly.)