### PR TITLE
Make executehooks public

### DIFF
--- a/server/src/serverLib/MainServer.js
+++ b/server/src/serverLib/MainServer.js
@@ -496,7 +496,7 @@ class MainServer extends WsServer {
     * @param {String} type The type of event, typically `in` (incoming) or `out` (outgoing)
     * @param {ws#WebSocket} socket Either target client or client (depends on `type`)
     * @param {Object} payload Either incoming data from client or outgoing data (depends on `type`)
-    * @private
+    * @public
     * @return {Object|Boolean}
     */
   executeHooks(type, socket, payload) {


### PR DESCRIPTION
Currently, you can 'simulate' running a command with `server.core.commands.handleCommand`, but you can't activate the hooks for your simulated command. By making it public, it would be an official way to run the hooks.  
Thoughts?