### PR TITLE
Fix null nick bug

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -320,7 +320,10 @@ function join(channel) {
 			if (location.hash) {
 				myNick = location.hash.substr(1);
 			} else {
-				myNick = prompt('Nickname:', myNick);
+				var newNick = prompt('Nickname:', myNick);
+				if (newNick !== null) {
+					myNick = newNick;
+				}
 			}
 		}
 


### PR DESCRIPTION
This should hopefully fix the really old bug where if you canceled the prompt (which can also happen by clicking outside of the prompt box on some browsers), the name might register as `null`.  
This bug usually occurred, like so:
User disconnects. (network problems, server issues, etc)  
Login prompt appears. They cancel out of it in some manner.  
`myNick = prompt('Nickname:', myNick);`  
`prompt` returns `null` if it was canceled. It returns `null` due to being cancelled, and so `myNick` is `null` now.  
This check:   
```javascript
if (myNick) {
	localStorageSet('my-nick', myNick);
	send({ cmd: 'join', channel: channel, nick: myNick });
}
```
Will stop it from storing `null` into `localStorage`, which is good, but if the user were to get *another* prompt despite having cancelled the prompt (their connection dies again, since the socket is *still* connected even if they didn't send a join and so reconnection logic still activates).  
Their `myNick = null` currently, so when we arrive back at the prompt:
`myNick = prompt('Nickname:', myNick);`  
Which, converts `myNick` (`null`) into `"null"`. Then if they automatically accept (pressing okay or enter), which they may very well be used to doing, their name is now stored in `localStorage` as `"null"`.  
This fix makes so it will not store the updated name as `null` if that is what is received, thus not throwing away their nick. They could still 'clear' the nick in `localStorage` via empty nickname or just a different nickname altogether.  
It may also be a good idea to make so if the user can't send their nick in join it just closes the socket altogether.