### PR TITLE
Fix auto-reconnect

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -316,6 +316,7 @@ function join(channel) {
 	var wasConnected = false;
 
 	ws.onopen = function () {
+		var shouldConnect = true;
 		if (!wasConnected) {
 			if (location.hash) {
 				myNick = location.hash.substr(1);
@@ -323,11 +324,14 @@ function join(channel) {
 				var newNick = prompt('Nickname:', myNick);
 				if (newNick !== null) {
 					myNick = newNick;
+				} else {
+					// The user cancelled the prompt in some manner
+					shouldConnect = false;
 				}
 			}
 		}
 
-		if (myNick) {
+		if (myNick && shouldConnect) {
 			localStorageSet('my-nick', myNick);
 			send({ cmd: 'join', channel: channel, nick: myNick });
 		}


### PR DESCRIPTION
Before my latest PR to make so that null-names could not happen (which was an issue for forever), if you cancelled the prompt then `myNick` was null and thus it would not attempt to join the channel at all. Now, since we never set `myNick` to null (thus avoiding the minor null-nick bug), it can join even though the prompt was cancelled (by user or by browser). This fixes it to the previous behavior, where it simply does not try to join.  
I believe bacon was experiencing this issue, and anti_lol.