### PR TITLE
Change tab-size to be more consistently 4

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -9,6 +9,9 @@ input,
 textarea {
   font-family: 'DejaVu Sans Mono', monospace;
   font-size: 12px;
+  tab-size: 4;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
 }
 input[type="checkbox"] {
   margin: 0;
@@ -35,6 +38,7 @@ pre {
   word-wrap: break-word;
   tab-size: 4;
   -moz-tab-size: 4;
+  -o-tab-size: 4;
 }
 a {
   color: inherit;


### PR DESCRIPTION
Browsers specify tab-size via css, the default being 8 spaces which is rather a lot.  
The tab size for pre tags (and thus code tags, since all code tags are inside of pre tags) has been 4 for quite some time, yet if you use a tab inside the input (since that is allowed now), it will be 8 characters. This pr makes the input textarea use tab-size now.  
It also adds `-o-tab-size` to the existing `pre` tag, just in case.  
There's three separate `tab-size` (woo css standardization..). `tab-size` which Chromium respects, `-moz-tab-size` which is for Firefox, and `-o-tab-size` which is for Opera.