### PR TITLE
Add the ability to log in multiple times as the same user

### DIFF
--- a/server/src/commands/core/changenick.js
+++ b/server/src/commands/core/changenick.js
@@ -53,6 +53,8 @@ export async function run(core, server, socket, data) {
     nick: (targetNick) => targetNick.toLowerCase() === newNick.toLowerCase() &&
       // Allow them to rename themselves to a different case
       targetNick != previousNick,
+    // Skip over multi-login versions of themselves
+    userid: (targetId) => targetId != socket.userid,
   });
 
   // return error if found
@@ -89,8 +91,15 @@ export async function run(core, server, socket, data) {
     text: `${socket.nick} is now ${newNick}`,
   }, { channel: socket.channel });
 
-  // commit change to nickname
-  socket.nick = newNick;
+  // Find any multi-login versions of themself to also update
+  // This will also include this socket
+  const users = server.findSockets({
+    userid: socket.userid,
+  });
+
+  for (let i = 0; i < users.length; i++) {
+    users[i].nick = newNick;
+  }
 
   return true;
 }

--- a/server/src/commands/core/move.js
+++ b/server/src/commands/core/move.js
@@ -79,13 +79,20 @@ export async function run(core, server, socket, data) {
   nicks.push(socket.nick);
 
   // reply with new user list
-  server.reply({
+  server.broadcast({
     cmd: 'onlineSet',
     nicks,
-  }, socket);
+  }, {
+    userid: socket.userid,
+  });
 
-  // commit change
-  socket.channel = data.channel;
+  const users = server.findSockets({
+    userid: socket.userid,
+  });
+  for (let i = 0; i < users; i++) {
+    // commit change
+    users[i].channel = data.channel;
+  }
 
   return true;
 }

--- a/server/src/commands/core/whisper.js
+++ b/server/src/commands/core/whisper.js
@@ -56,15 +56,17 @@ export async function run(core, server, socket, payload) {
     }, socket);
   }
 
-  [targetClient] = targetClient;
-
-  server.reply({
-    cmd: 'info',
-    type: 'whisper',
-    from: socket.nick,
-    trip: socket.trip || 'null',
-    text: `${socket.nick} whispered: ${text}`,
-  }, targetClient);
+  const targetText = `${socket.nick} whispered: ${text}`;
+  for (let i = 0; i < targetClient.length; i++) {
+    const target = targetClient[i];
+    server.reply({
+      cmd: 'info',
+      type: 'whisper',
+      from: socket.nick,
+      trip: socket.trip || 'null',
+      text: targetText,
+    }, target);
+  }
 
   targetClient.whisperReply = socket.nick;
 

--- a/server/src/commands/internal/disconnect.js
+++ b/server/src/commands/internal/disconnect.js
@@ -12,6 +12,16 @@ export async function run(core, server, socket, data) {
 
   // send leave notice to client peers
   if (socket.channel) {
+    const users = server.findSockets({
+      userid: socket.userid,
+    });
+
+    // TODO: We could do some shenanigans to unlink the original id if that was the one that dced
+    // If there is still a user after a dc, then that means they are still on
+    if (users.length > 0) {
+      return false;
+    }
+
     server.broadcast({
       cmd: 'onlineRemove',
       nick: socket.nick,

--- a/server/src/commands/mod/speak.js
+++ b/server/src/commands/mod/speak.js
@@ -55,6 +55,16 @@ export async function run(core, server, socket, data) {
 
   delete core.muzzledHashes[target];
 
+  // Also remove muzzle on associated hashes for multilogin users
+  const users = server.findSockets({
+    hash: target,
+  });
+  for (let i = 0; i < users.length; i++) {
+    if (users[i].originalHash) {
+      delete core.muzzledHashes[originalHash];
+    }
+  }
+
   // notify mods
   server.broadcast({
     cmd: 'info',


### PR DESCRIPTION
This pull-request adds a feature that has been requested in the patch (aka blame _0x17) of being able to login with the same nick+trip and control the same client as before.  
This obviously required some changes to the code.  
For the most part, this makes them indistinguishable to the clients. The server internally handles differences between them, such as a ban applying to both sockets since they can have different hashes.  
 - To the clients, only the original hash is displayed
 - This currently does not handle ratelimit, though this wouldn't be too rough to add. It just requires replacing all the usage of `frisk` with something that takes `server` and `userid` to do `findSockets` with then does the typical frisking.  I don't think this is too major, since it would only allow swapping proxies/whatever while keeping the same name and avoiding ratelimit like that.
 - Not all data is replicated across sockets, such as some command output. This could be done, but eh.  

There's probably bugs. I did some testing, but less than I should have.