### PR TITLE
Faster operation(PLUS)

### DIFF
--- a/commands/admin/addmod.js
+++ b/commands/admin/addmod.js
@@ -104,5 +104,12 @@ export const info = {
   category: 'admin',
   description: 'Adds target trip to the config as a mod and upgrades the socket type',
   usage: `
-    API: { cmd: 'addmod', trip: '<target trip>' }`,
+    API: { cmd: 'addmod', trip: '<target trip>' }
+    Text: /addmod <target trip>`,
+  fastcmd:[
+    {
+      name:'trip',
+      len:1
+    }
+  ]
 };

--- a/commands/admin/listusers.js
+++ b/commands/admin/listusers.js
@@ -73,5 +73,7 @@ export const info = {
   category: 'admin',
   description: 'Outputs all current channels and sockets in those channels',
   usage: `
-    API: { cmd: 'listusers' }`,
+    API: { cmd: 'listusers' }
+    Text: /listusers`,
+  fastcmd:[]
 };

--- a/commands/admin/reload.js
+++ b/commands/admin/reload.js
@@ -67,5 +67,10 @@ export const info = {
   category: 'admin',
   description: 'Allows a remote user to clear and re-import the server command modules',
   usage: `
-    API: { cmd: 'reload', reason: '<optional reason append>' }`,
+    API: { cmd: 'reload', reason: '<optional reason append>' }
+    Text: /reload <optional reason append>`,
+  fastcmd:[{
+    name:'reason',
+    len:0
+  }]
 };

--- a/commands/admin/removemod.js
+++ b/commands/admin/removemod.js
@@ -109,5 +109,12 @@ export const info = {
   category: 'admin',
   description: 'Removes target trip from the config as a mod and downgrades the socket type',
   usage: `
-    API: { cmd: 'removemod', trip: '<target trip>' }`,
+    API: { cmd: 'removemod', trip: '<target trip>' }
+    Text: /removemod <target trip>`,
+  fastcmd:[
+    {
+      name:'trip',
+      len:1
+    }
+  ]
 };

--- a/commands/admin/saveconfig.js
+++ b/commands/admin/saveconfig.js
@@ -58,5 +58,7 @@ export const info = {
   category: 'admin',
   description: 'Writes the current config to disk',
   usage: `
-    API: { cmd: 'saveconfig' }`,
+    API: { cmd: 'saveconfig' }
+    Text: /saveconfig`,
+  fastcmd:[]
 };

--- a/commands/admin/shout.js
+++ b/commands/admin/shout.js
@@ -54,5 +54,12 @@ export const info = {
   category: 'admin',
   description: 'Displays passed text to every client connected',
   usage: `
-    API: { cmd: 'shout', text: '<shout text>' }`,
+    API: { cmd: 'shout', text: '<shout text>' }
+    Text: /shout <shout text>`,
+  fastcmd:[
+    {
+      name:'text',
+      len:0
+    }
+  ]
 };

--- a/commands/internal/fastcmd.js
+++ b/commands/internal/fastcmd.js
@@ -1,0 +1,74 @@
+export async function run(core, server, socket, payload) {
+  //nothing
+  return true
+}
+// module hook functions
+export function initHooks(server) {
+  server.registerHook('in', 'chat', this.fastcmd.bind(this), 253);
+}
+
+export function isArray(myArray) {
+  return myArray.constructor.toString().indexOf("Array") > -1;
+}
+
+export function fastcmd({core, server, socket, payload}) {
+  if (typeof payload.text !== 'string') {
+    return false;
+  }
+  const cmdlist = payload.text.split(' ')
+  
+  //检查是否以“/”开头
+  if (!cmdlist[0].startsWith('/')){
+    return payload
+  }
+
+  //是否转义
+  if (cmdlist[0].startsWith('//')){
+    return payload
+  }
+
+  const cmdName = cmdlist[0].slice(1);    //获取命令名称
+  const command = core.commands.get(cmdName)    //找命令模块
+
+  if (!command){    //如果找不到
+    return payload
+  }
+  
+  if (!command.info.fastcmd){
+    return payload    //如果模块没有启用fastcmd支持
+  }
+  //声明变量
+  var i = 0
+  var cut = 1
+  var fakePayload = {    //假的数据包
+    cmd:cmdName,
+  }
+
+  for (i in command.info.fastcmd){    //构建假的数据包
+    if (command.info.fastcmd[i].len === 0){    //如果要求的长度为0，则代表通吃所有内容
+      var temp = cmdlist.slice(cut,cmdlist.length)
+      if (temp.length === 0){
+        continue
+      }
+      fakePayload[command.info.fastcmd[i].name] = temp.join(' ')    //给你吧
+      break    //没用了，结束循环吧
+    }
+    var temp = cmdlist.slice(cut,cut+command.info.fastcmd[i].len)
+    if (temp.length === 0){
+      continue
+    }
+    fakePayload[command.info.fastcmd[i].name] = temp.join(' ')    //截取数组，然后join一下
+    cut += command.info.fastcmd[i].len
+  }
+  server.handleData(socket,JSON.stringify(fakePayload))
+  return false
+}
+
+
+export const info = {
+  name: 'fastcmd',
+  category: 'internal',
+  description: 'This module allows you to quickly execute commands by sending information similar to the `/command parameter`.',
+  usage: `
+    idk`,
+};

--- a/commands/mod/ban.js
+++ b/commands/mod/ban.js
@@ -111,5 +111,12 @@ export const info = {
   category: 'moderators',
   description: 'Bans target user by name',
   usage: `
-    API: { cmd: 'ban', nick: '<target nickname>' }`,
+    API: { cmd: 'ban', nick: '<target nickname>' }
+    Text: /ban <target nickname>`,
+  fastcmd:[
+    {
+      name:'nick',
+      len:1
+    }
+  ]
 };

--- a/commands/mod/dumb.js
+++ b/commands/mod/dumb.js
@@ -369,5 +369,12 @@ export const info = {
   description: 'Globally shadow mute a connection. Optional allies array will see muted messages.',
   aliases: ['muzzle', 'mute'],
   usage: `
-    API: { cmd: 'dumb', nick: '<target nick>', allies: ['<optional nick array>', ...] }`,
+    API: { cmd: 'dumb', nick: '<target nick>', allies: ['<optional nick array>', ...] }
+    Text: /dumb <target nick>`,
+  fastcmd:[
+    {
+      name:'nick',
+      len:1
+    }
+  ]
 };

--- a/commands/mod/kick.js
+++ b/commands/mod/kick.js
@@ -148,5 +148,16 @@ export const info = {
   category: 'moderators',
   description: 'Silently forces target client(s) into another channel. `nick` may be string or array of strings',
   usage: `
-    API: { cmd: 'kick', nick: '<target nick>', to: '<optional target channel>' }`,
+    API: { cmd: 'kick', nick: '<target nick>', to: '<optional target channel>' }
+    Text: /kick <target nick>`,
+  fastcmd:[
+    {
+      name:'nick',
+      len:1
+    },
+    {
+      name:'to',
+      len:1
+    }
+  ]
 };

--- a/commands/mod/speak.js
+++ b/commands/mod/speak.js
@@ -102,5 +102,12 @@ export const info = {
   description: 'Pardon a dumb user to be able to speak again',
   aliases: ['unmuzzle', 'unmute'],
   usage: `
-    API: { cmd: 'speak', ip/hash: '<target ip or hash' }`,
+    API: { cmd: 'speak', ip/hash: '<target ip or hash' }
+    Text: /speak <target ==hash==>`,
+  fastcmd:[
+    {
+      name:'hash',
+      len:1
+    }
+  ]
 };

--- a/commands/mod/unban.js
+++ b/commands/mod/unban.js
@@ -87,5 +87,12 @@ export const info = {
   category: 'moderators',
   description: 'Un-bans target user by ip or hash',
   usage: `
-    API: { cmd: 'unban', ip/hash: '<target ip or hash>' }`,
+    API: { cmd: 'unban', ip/hash: '<target ip or hash>' }
+    Text: /unban <target ==hash==>`,
+  fastcmd:[
+    {
+      name:'hash',
+      len: 1
+    }
+  ]
 };

--- a/commands/mod/unbanall.js
+++ b/commands/mod/unbanall.js
@@ -60,5 +60,7 @@ export const info = {
   category: 'moderators',
   description: 'Clears all banned ip addresses',
   usage: `
-    API: { cmd: 'unbanall' }`,
+    API: { cmd: 'unbanall' }
+    Text: /unbanall`,
+  fastcmd:[]
 };


### PR DESCRIPTION
This pull request is to complete [the last pull request](https://github.com/hack-chat/main/pull/173).  
I added a  module called `fastcmd.js`, which can execute all mod and admin categories commands with only one hook.
Compared with the last pull request, this time only one hook was added, which saves valuable server resources. At the same time, almost every module of mod and admin categories added an array called `fastcmd` to tell `fastcmd.js` how to recognize the user's input information.  
Hope to succeed this time, and can you give me an "authtrip"?