### PR TITLE
Impl updateMessage command

### DIFF
--- a/commands/core/updateMessage.js
+++ b/commands/core/updateMessage.js
@@ -1,0 +1,97 @@
+import { parseText } from "../utility/_Text.js";
+import { isAdmin, isModerator } from "../utility/_UAC.js";
+import { ACTIVE_MESSAGES, MAX_MESSAGE_ID_LENGTH } from "./chat.js";
+
+export async function run({ core, server, socket, payload }) {
+  // undefined | "overwrite" | "append" | "prepend"
+  let mode = payload.mode;
+
+  if (!mode) {
+    mode = 'overwrite';
+  }
+
+  if (mode !== 'overwrite' && mode !== 'append' && mode !== 'prepend') {
+    return server.police.frisk(socket.address, 13);
+  }
+
+  const customId = payload.customId;
+
+  if (!customId || typeof customId !== "string" || customId.length > MAX_MESSAGE_ID_LENGTH) {
+    return server.police.frisk(socket.address, 13);
+  }
+
+  let text = payload.text;
+
+  if (typeof (text) !== 'string') {
+    return server.police.frisk(socket.address, 13);
+  }
+
+  if (mode === 'overwrite') {
+    text = parseText(text);
+
+    if (text === '') {
+      text = '\u0000';
+    }
+  }
+
+  if (!text) {
+    return server.police.frisk(socket.address, 13);
+  }
+
+  // TODO: What score should we use for this? It isn't as space filling as chat messages.
+  // But we also don't want a massive growing message.
+  // Or flashing between huge and small. Etc.
+
+  let message;
+  for (let i = 0; i < ACTIVE_MESSAGES.length; i++) {
+    const msg = ACTIVE_MESSAGES[i];
+
+    if (msg.userid === socket.userid && msg.customId === customId) {
+      message = ACTIVE_MESSAGES[i];
+      break;
+    }
+  }
+
+  if (!message) {
+    return server.police.frisk(socket.address, 6);
+  }
+
+  const outgoingPayload = {
+    cmd: 'updateMessage',
+    userid: socket.userid,
+    channel: socket.channel,
+    level: socket.level,
+    mode,
+    text,
+    customId: message.customId,
+  };
+
+  if (isAdmin(socket.level)) {
+    outgoingPayload.admin = true;
+  } else if (isModerator(socket.level)) {
+    outgoingPayload.mod = true;
+  }
+
+  server.broadcast(outgoingPayload, { channel: socket.channel });
+
+  return true;
+}
+
+export const requiredData = ['text', 'customId'];
+
+/**
+  * Module meta information
+  * @public
+  * @typedef {Object} updateMessage/info
+  * @property {string} name - Module command name
+  * @property {string} category - Module category name
+  * @property {string} description - Information about module
+  * @property {string} usage - Information about module usage
+  */
+export const info = {
+  name: 'updateMessage',
+  category: 'core',
+  description: 'Update a message you have sent.',
+  usage: `
+    API: { cmd: 'updateMessage', mode: 'overwrite'|'append'|'prepand', text: '<text to apply>',customId: '<customId sent with the chat message>' }`,
+};

--- a/commands/utility/_Text.js
+++ b/commands/utility/_Text.js
@@ -1,0 +1,21 @@
+/**
+  * Check and trim string provided by remote client
+  * @public
+  * @param {string} text - Subject string
+  * @return {string|null}
+  */
+export const parseText = (text) => {
+  // verifies user input is text
+  if (typeof text !== 'string') {
+    return null;
+  }
+
+  let sanitizedText = text;
+
+  // strip newlines from beginning and end
+  sanitizedText = sanitizedText.replace(/^\s*\n|^\s+$|\n\s*$/g, '');
+  // replace 3+ newlines with just 2 newlines
+  sanitizedText = sanitizedText.replace(/\n{3,}/g, '\n\n');
+
+  return sanitizedText;
+};


### PR DESCRIPTION
This PR adds an `updateMessage` command which lets clients update (overwrite | append | prepend) their messages. It has a timeout, after which messages are not allowed to be modified.  
In the legacy client this does not delete the message entirely if it is overwritten by nothing, to avoid shenanigans.

The `chat` command has a `customId` field, which is a short string that can be used to identify the message. This lets the client decide what id their message will have, which makes it easy to refer to in future update commands. Two clients can use the same custom id, because the active messages are differentiated by their userid.
  
Example usage:
Send:
```json
{
    "cmd": "chat",
    "text": "Hello",
    "customId": "1", // whatever the client wants, up to six chars
}
```
Clients will receive:
```json
{
    "cmd": "chat",
    "text": "Hello",
    "nick": "MinusGix",
    "trip": "Rdais/",
    "customId": "1",
}
```
Send:
```json
{
    "cmd": "updateMessage",
    "customId": "1",
    "mode": "append",
    "text": " world!"
}
```
Clients will receive:
```json
{
    "cmd": "updateMessage",
    "customId": "1",
    "mode": "append",
    "text": " world!",
    // userid, channel, level, etc.
}
```