### PR TITLE
added user types to the list on sidebar

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -808,6 +808,7 @@ function userIgnore(nick) {
 /* color scheme switcher */
 
 var schemes = [
+	'amoled',
 	'android',
 	'android-white',
 	'atelier-dune',
@@ -818,12 +819,16 @@ var schemes = [
 	'banana',
 	'bright',
 	'bubblegum',
+	'carrot',
 	'chalk',
 	'default',
 	'eighties',
 	'fresh-green',
+	'fried-egg',
 	'greenscreen',
+	'gruvbox-light',
 	'hacker',
+	'lax',
 	'maniac',
 	'mariana',
 	'military',
@@ -834,16 +839,12 @@ var schemes = [
 	'omega',
 	'pop',
 	'railscasts',
+	'rainbow',
+	'retro',
 	'solarized',
 	'tk-night',
 	'tomorrow',
-	'carrot',
-	'lax',
-	'Ubuntu',
-	'gruvbox-light',
-	'fried-egg',
-	'rainbow',
-	'amoled'
+	'Ubuntu'
 ];
 
 var highlights = [

--- a/client/client.js
+++ b/client/client.js
@@ -385,11 +385,12 @@ var COMMANDS = {
 
 	onlineSet: function (args) {
 		var nicks = args.nicks;
+		var users = args.users;
 
 		usersClear();
 
-		nicks.forEach(function (nick) {
-			userAdd(nick);
+		users.forEach(function (user) {
+			userAdd(user.nick, user.utype);
 		});
 
 		pushMessage({ nick: '*', text: "Users online: " + nicks.join(", ") })
@@ -397,8 +398,9 @@ var COMMANDS = {
 
 	onlineAdd: function (args) {
 		var nick = args.nick;
+		var utype = args.utype
 
-		userAdd(nick);
+		userAdd(nick, utype);
 
 		if ($('#joined-left').checked) {
 			pushMessage({ nick: '*', text: nick + " joined" });
@@ -751,7 +753,7 @@ $('#allow-imgur').onchange = function (e) {
 var onlineUsers = [];
 var ignoredUsers = [];
 
-function userAdd(nick) {
+function userAdd(nick, utype) {
 	var user = document.createElement('a');
 	user.textContent = nick;
 
@@ -761,6 +763,9 @@ function userAdd(nick) {
 
 	var userLi = document.createElement('li');
 	userLi.appendChild(user);
+	if (utype && ['admin','mod','user'].includes(utype)){
+		userLi.className = utype;
+	}
 	$('#users').appendChild(userLi);
 	onlineUsers.push(nick);
 }


### PR DESCRIPTION
added user types to the userlist on sidebar, main reason for this change was to be able to use the sidebar as main part of the design in theming, like its being used in the [retro theme](https://github.com/hack-chat/main/pull/221).

![image](https://github.com/hack-chat/main/assets/87977405/043804de-6a47-4370-9a71-d2cea10141b6)
![image](https://github.com/hack-chat/main/assets/87977405/c8cf648d-9c3b-4c25-97be-dbf03e2e48db)
