### PR TITLE
Add `complete` mode to `updateMessage`

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -412,6 +412,10 @@ var COMMANDS = {
 		for (var i = 0; i < activeMessages.length; i++) {
 			var msg = activeMessages[i];
 			if (msg.userid === args.userid && msg.customId === customId) {
+				if (mode === 'complete') {
+					activeMessages.splice(i, 1);
+					return;
+				}
 				message = msg;
 				break;
 			}

--- a/commands/core/chat.js
+++ b/commands/core/chat.js
@@ -40,7 +40,7 @@ export function cleanActiveMessages() {
   const now = Date.now();
   for (let i = 0; i < ACTIVE_MESSAGES.length; i++) {
     const message = ACTIVE_MESSAGES[i];
-    if (now - message.sent > ACTIVE_TIMEOUT) {
+    if (now - message.sent > ACTIVE_TIMEOUT || message.toDelete) {
       ACTIVE_MESSAGES.splice(i, 1);
       i--;
     }
@@ -62,6 +62,7 @@ export function addActiveMessage(customId, userid) {
     customId,
     userid,
     sent: Date.now(),
+    toDelete: false,
   });
 }
 

--- a/commands/core/updateMessage.js
+++ b/commands/core/updateMessage.js
@@ -3,14 +3,14 @@ import { isAdmin, isModerator } from "../utility/_UAC.js";
 import { ACTIVE_MESSAGES, MAX_MESSAGE_ID_LENGTH } from "./chat.js";
 
 export async function run({ core, server, socket, payload }) {
-  // undefined | "overwrite" | "append" | "prepend"
+  // undefined | "overwrite" | "append" | "prepend" | "complete"
   let mode = payload.mode;
 
   if (!mode) {
     mode = 'overwrite';
   }
 
-  if (mode !== 'overwrite' && mode !== 'append' && mode !== 'prepend') {
+  if (mode !== 'overwrite' && mode !== 'append' && mode !== 'prepend' && mode !== 'complete') {
     return server.police.frisk(socket.address, 13);
   }
 
@@ -93,5 +93,5 @@ export const info = {
   category: 'core',
   description: 'Update a message you have sent.',
   usage: `
-    API: { cmd: 'updateMessage', mode: 'overwrite'|'append'|'prepend', text: '<text to apply>', customId: '<customId sent with the chat message>' }`,
+    API: { cmd: 'updateMessage', mode: 'overwrite'|'append'|'prepend'|'complete', text: '<text to apply>', customId: '<customId sent with the chat message>' }`,
 };

--- a/commands/core/updateMessage.js
+++ b/commands/core/updateMessage.js
@@ -48,9 +48,6 @@ export async function run({ core, server, socket, payload }) {
 
     if (msg.userid === socket.userid && msg.customId === customId) {
       message = ACTIVE_MESSAGES[i];
-      if (mode === 'complete') {
-        ACTIVE_MESSAGES.splice(i, 1);
-      }
       break;
     }
   }

--- a/commands/core/updateMessage.js
+++ b/commands/core/updateMessage.js
@@ -93,5 +93,5 @@ export const info = {
   category: 'core',
   description: 'Update a message you have sent.',
   usage: `
-    API: { cmd: 'updateMessage', mode: 'overwrite'|'append'|'prepand', text: '<text to apply>',customId: '<customId sent with the chat message>' }`,
+    API: { cmd: 'updateMessage', mode: 'overwrite'|'append'|'prepend', text: '<text to apply>', customId: '<customId sent with the chat message>' }`,
 };

--- a/commands/core/updateMessage.js
+++ b/commands/core/updateMessage.js
@@ -48,6 +48,9 @@ export async function run({ core, server, socket, payload }) {
 
     if (msg.userid === socket.userid && msg.customId === customId) {
       message = ACTIVE_MESSAGES[i];
+      if (mode === 'complete') {
+        ACTIVE_MESSAGES.splice(i, 1);
+      }
       break;
     }
   }

--- a/commands/core/updateMessage.js
+++ b/commands/core/updateMessage.js
@@ -48,6 +48,9 @@ export async function run({ core, server, socket, payload }) {
 
     if (msg.userid === socket.userid && msg.customId === customId) {
       message = ACTIVE_MESSAGES[i];
+      if (mode === 'complete') {
+        ACTIVE_MESSAGES[i].toDelete = true;
+      }
       break;
     }
   }


### PR DESCRIPTION
This PR fixes a minor typo and adds a `complete` mode to `updateMessage`.
Informs clients and bots when an active message is complete and should be locked.