### PR TITLE
sorting arrays (schemes and highlights) as they are added to the dropdown menu

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -1011,15 +1011,22 @@ function setHighlight(scheme) {
 	localStorageSet('highlight', scheme);
 }
 
+function sortArrayCaseInsenstive(array) {
+  return array.sort((a, b) => {
+    return a.toLowerCase().localeCompare(b.toLowerCase());
+  });
+}
+
+
 // Add scheme options to dropdown selector
-schemes.forEach(function (scheme) {
+sortArrayCaseInsenstive(schemes).forEach(function (scheme) {
 	var option = document.createElement('option');
 	option.textContent = scheme;
 	option.value = scheme;
 	$('#scheme-selector').appendChild(option);
 });
 
-highlights.forEach(function (scheme) {
+sortArrayCaseInsenstive(highlights).forEach(function (scheme) {
 	var option = document.createElement('option');
 	option.textContent = scheme;
 	option.value = scheme;


### PR DESCRIPTION
im not sure if this would even be useful, but not many users take in the time to place their added schemes in a proper order, so this might remove the need to even do so.

it just sorts the array case-insensitively (since the sorting method just returns the reference to the same array sorted it would break the setScheme/setHighlight functions) right before adding them to the dropdown menu for choosing the theme