### PR TITLE
custom schemes

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -51,6 +51,7 @@ var allowImages = false;
 var imgHostWhitelist = [
 	'i.imgur.com',
 	'imgur.com',
+  'imgs.xkcd.com',
 ];
 
 function getDomain(link) {

--- a/client/client.js
+++ b/client/client.js
@@ -9,10 +9,10 @@
 
 //select "chatinput" on "/"
 document.addEventListener("keydown", e => {
-    if (e.key === '/' && document.getElementById("chatinput") != document.activeElement) {
-        e.preventDefault();
-        document.getElementById("chatinput").focus();
-    }
+	if (e.key === '/' && document.getElementById("chatinput") != document.activeElement) {
+		e.preventDefault();
+		document.getElementById("chatinput").focus();
+	}
 });
 
 // initialize markdown engine
@@ -771,7 +771,7 @@ $('#chatinput').onkeydown = function (e) {
 // from https://stackoverflow.com/questions/11381673/detecting-a-mobile-browser
 function checkIsMobileOrTablet() {
 	let check = false;
-	(function(a){if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4))) check = true;})(navigator.userAgent||navigator.vendor||window.opera);
+	(function (a) { if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0, 4))) check = true; })(navigator.userAgent || navigator.vendor || window.opera);
 	return check;
 };
 
@@ -1000,12 +1000,58 @@ var highlights = [
 	'zenburn'
 ]
 
+var userSchemes = Object.keys(localStorage).filter(scheme => scheme.endsWith('-user-scheme'))
+schemes = schemes.concat(userSchemes)
+
 var currentScheme = 'atelier-dune';
 var currentHighlight = 'darcula';
 
+
+
+async function fetchUserScheme(url) {
+	try {
+		const response = await fetch(url);
+		if (!response.ok) {
+			console.error(`HTTP error: ${response.status}`);
+		} else {
+			const cssName = () => {
+				url = url.split('/')
+				url = url[url.length - 1].split('.')[0]
+				return url + '-user-scheme'
+			};
+			if (userSchemes.includes(cssName())) {
+				console.info('already have a css file with the same name')
+			} else {
+				const cssContent = await response.text()
+				localStorage.setItem(cssName(), cssContent)
+				updateSchemes()
+			}
+		}
+
+	} catch (error) { console.error(error) }
+}
+
+function updateSchemes() {
+	let localSchemes = Object.keys(localStorage).filter(scheme => scheme.endsWith('-user-scheme'))
+	localSchemes.forEach(scheme => userSchemes.push(scheme))
+	userSchemes = [...new Set(userSchemes)]
+}
+
+
+function localStorageToURL(localName, filetype = 'text/css') {
+	const localFile = localStorage.getItem(localName)
+	const content = decodeURIComponent(localFile);
+	const blob = new Blob([content], { type: filetype });
+	const url = URL.createObjectURL(blob);
+	return url;
+}
 function setScheme(scheme) {
+	if (!scheme.endsWith('-user-scheme')) {
+		$('#scheme-link').href = "schemes/" + scheme + ".css";
+	} else {
+		$('#scheme-link').href = localStorageToURL(scheme)
+	}
 	currentScheme = scheme;
-	$('#scheme-link').href = "schemes/" + scheme + ".css";
 	localStorageSet('scheme', scheme);
 }
 
@@ -1015,22 +1061,22 @@ function setHighlight(scheme) {
 	localStorageSet('highlight', scheme);
 }
 
-function sortArrayCaseInsenstive(array) {
-  return array.sort((a, b) => {
-    return a.toLowerCase().localeCompare(b.toLowerCase());
-  });
+function sortArrayCaseInsensitive(array) {
+	return array.sort((a, b) => {
+		return a.toLowerCase().localeCompare(b.toLowerCase());
+	});
 }
 
 
 // Add scheme options to dropdown selector
-sortArrayCaseInsenstive(schemes).forEach(function (scheme) {
+sortArrayCaseInsensitive(schemes).forEach(function (scheme) {
 	var option = document.createElement('option');
 	option.textContent = scheme;
 	option.value = scheme;
 	$('#scheme-selector').appendChild(option);
 });
 
-sortArrayCaseInsenstive(highlights).forEach(function (scheme) {
+sortArrayCaseInsensitive(highlights).forEach(function (scheme) {
 	var option = document.createElement('option');
 	option.textContent = scheme;
 	option.value = scheme;


### PR DESCRIPTION
very basic implementation of the custom schemes talked in #240, users can call the ``fetchUserScheme(url)`` function from console to add their scheme, it gets stored in localStorage so they are gone once you reset the cache, and the scheme gets added amongst the other schemes after a reload of the page with post-fix of ``-user-scheme``. the url domain should allow for CORS for example, the https://raw.githubusercontent.com allows it, so you could upload your schemes to a github repo and get their link from that domain (aka just viewing the raw file will provide you that link).

not very user friendly having to go to console for such thing, but i liked the idea too much.

also fixed a typo from previous PR and some formatting is done on some lines (nothing major).