### PR TITLE
Fix incorrect handling of undefined newPayload.pass in upgradeLegacyJoin

### DIFF
--- a/commands/utility/_LegacyFunctions.js
+++ b/commands/utility/_LegacyFunctions.js
@@ -24,6 +24,8 @@ import {
 export function upgradeLegacyJoin(server, socket, payload) {
   const newPayload = payload;
 
+  if (!newPayload.pass) newPayload.pass = '';
+
   // `join` is the legacy entry point, so apply protocol version
   socket.hcProtocol = 1;
 


### PR DESCRIPTION
I noticed that when enabling the captcha, using the **official client** to join **(without using a password)** adds an tripcode: **LPFQmL**. 
![image](https://github.com/user-attachments/assets/e3f5e437-b451-4814-8c3c-105b68b08e03)

Similarly, hack.chat++ also has this issue, but FoxHC does not. I compared the differences in the data packets they send upon joining and found that FoxHC declares **the password using the passwd/password field**. 

This made me think that perhaps the tripcode `LPFQmL` is generated because this field is empty. 
I used `undefined` as the password and indeed got the tripcode `LPFQmL`.

Finally, I discovered that `upgradeLegacyJoin` would not modify `newPayload.pass` when **it was undefined and no password was specified via nickname**. This caused the returned payload's `pass` field to remain **undefined**, leading to incorrect tripcode generation.